### PR TITLE
Fix Campaigns 2 and 3. Add Experience reward to levels

### DIFF
--- a/client/Assets/Prefabs/Campaigns/Campaign2.prefab
+++ b/client/Assets/Prefabs/Campaigns/Campaign2.prefab
@@ -4134,6 +4134,11 @@ PrefabInstance:
       propertyPath: campaignToComplete
       value: Campaign_2
       objectReference: {fileID: 0}
+    - target: {fileID: 1708985256918421095, guid: b9905ae9753b542f18093f7a97853e0c,
+        type: 3}
+      propertyPath: individualRewards.Array.data[1].name
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1932950366438959233, guid: b9905ae9753b542f18093f7a97853e0c,
         type: 3}
       propertyPath: m_Name

--- a/client/Assets/Prefabs/Campaigns/Campaign3.prefab
+++ b/client/Assets/Prefabs/Campaigns/Campaign3.prefab
@@ -17,6 +17,11 @@ PrefabInstance:
       propertyPath: campaignToComplete
       value: Campaign_3
       objectReference: {fileID: 0}
+    - target: {fileID: 1708985256918421095, guid: b9905ae9753b542f18093f7a97853e0c,
+        type: 3}
+      propertyPath: individualRewards.Array.data[1].name
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1932950366438959233, guid: b9905ae9753b542f18093f7a97853e0c,
         type: 3}
       propertyPath: m_Name

--- a/client/Assets/Prefabs/Campaigns/SimpleCampaign.prefab
+++ b/client/Assets/Prefabs/Campaigns/SimpleCampaign.prefab
@@ -811,17 +811,17 @@ PrefabInstance:
     - target: {fileID: 114754063598300098, guid: f9fa21dca98874c4196e015010414446,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.1882353
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 114754063598300098, guid: f9fa21dca98874c4196e015010414446,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.23921569
+      value: 0.7607843
       objectReference: {fileID: 0}
     - target: {fileID: 114754063598300098, guid: f9fa21dca98874c4196e015010414446,
         type: 3}
       propertyPath: m_Color.r
-      value: 1
+      value: 0.34509805
       objectReference: {fileID: 0}
     - target: {fileID: 114902987647824782, guid: f9fa21dca98874c4196e015010414446,
         type: 3}

--- a/client/Assets/Prefabs/Level/LevelMarker.prefab
+++ b/client/Assets/Prefabs/Level/LevelMarker.prefab
@@ -671,8 +671,9 @@ MonoBehaviour:
   - {fileID: 0}
   levels: 0000000000000000000000000000000000000000
   individualRewards:
-  - name: gold
+  - name: 0
     value: 15
+  experienceReward: 25
   nextLevel: {fileID: 0}
   lockObject: {fileID: 3229416807145212521}
   completedCrossObject: {fileID: 3296925110222054232}

--- a/client/Assets/Scenes/CampaignsMap.unity
+++ b/client/Assets/Scenes/CampaignsMap.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3708708, g: 0.37838137, b: 0.35725543, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311924, g: 0.38073963, b: 0.3587269, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -320,6 +320,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 592328169953432731, guid: 580c190a426d64bc2adb1771024b893c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 592328170399732798, guid: 580c190a426d64bc2adb1771024b893c,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -474,6 +479,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2164660845166415705, guid: 580c190a426d64bc2adb1771024b893c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2164660845166415705, guid: 580c190a426d64bc2adb1771024b893c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2164660845166415705, guid: 580c190a426d64bc2adb1771024b893c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2164660845166415705, guid: 580c190a426d64bc2adb1771024b893c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3139780143661254536, guid: 580c190a426d64bc2adb1771024b893c,
         type: 3}
@@ -745,7 +770,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 634500195}
+      objectReference: {fileID: 0}
     - target: {fileID: 114745404925296982, guid: f9fa21dca98874c4196e015010414446,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
@@ -947,12 +972,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 28ecea33205204bf99fab8c779ea6abc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!82 &634500195 stripped
-AudioSource:
-  m_CorrespondingSourceObject: {fileID: 2277539832404413938, guid: f9fa21dca98874c4196e015010414446,
-    type: 3}
-  m_PrefabInstance: {fileID: 634500192}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1045099588
 GameObject:
   m_ObjectHideFlags: 0
@@ -1159,6 +1178,12 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 536687278}
     m_Modifications:
+    - target: {fileID: 3918512608832285016, guid: b976b0f1477c04167ab8adef6b5cfa20,
+        type: 3}
+      propertyPath: campaingToShowPrefab
+      value: 
+      objectReference: {fileID: 8786978889612564449, guid: afd06a7b2be0949728dc75faea36cc3e,
+        type: 3}
     - target: {fileID: 5425641655313808468, guid: b976b0f1477c04167ab8adef6b5cfa20,
         type: 3}
       propertyPath: m_SizeDelta.y


### PR DESCRIPTION
Hotfix to make campaigns 2 and 3 work again. Also adds experience back to levels.

All changes are through unity inspector. To check if they work you can reach campaign 3 and finish it! (yes you will have to do a lot of clicking. or just trust that it works. ooooor set the second campaign first level's next level to one of the last levels if you're a cheater.)