### PR TITLE
change sprite field to template

### DIFF
--- a/client/Assets/Scripts/Item.cs
+++ b/client/Assets/Scripts/Item.cs
@@ -11,9 +11,6 @@ public class Item
     public ItemTemplate template;
     public string userId;
     public string unitId;
-    // Hardcoded sprite, should get from backend
-    public Sprite icon = Resources.Load<Sprite>("UI/Equipment/PlaceholderSprite");
-
     public int GetLevelUpCost() {
         return (int)Math.Pow(level, 2);
     }
@@ -24,4 +21,6 @@ public class ItemTemplate
     public string id;
     public string name;
     public string type;
+    // Hardcoded sprite, should get from backend
+    public Sprite icon = Resources.Load<Sprite>("UI/Equipment/PlaceholderSprite");
 }

--- a/client/Assets/Scripts/UnitDetail/UIEquipmentSlot.cs
+++ b/client/Assets/Scripts/UnitDetail/UIEquipmentSlot.cs
@@ -41,7 +41,7 @@ public class UIEquipmentSlot : MonoBehaviour
     {
         this.equippedItem = item;
         if(item != null) {
-            equipmentIcon.sprite = item.icon;
+            equipmentIcon.sprite = item.template.icon;
             equipmentIcon.gameObject.SetActive(true);
             slotIcon.gameObject.SetActive(false);
             actionIcon.sprite = removeIconSprite;


### PR DESCRIPTION
Closes #162 

## Motivation

An item's image is determined by it's template, not by the instance of the item (every instance of an item template, which is an item, will have the same icon sprite, the same as the name of the items).

## Summary of changes

Moved the icon field from Item class to ItemTemplate class.