### PR TITLE
Fix Lineup screen can select same unit multiple times

### DIFF
--- a/client/Assets/Scripts/Lineup/LineUpUnitsUIContainer.cs
+++ b/client/Assets/Scripts/Lineup/LineUpUnitsUIContainer.cs
@@ -14,7 +14,7 @@ public class LineUpUnitsUIContainer : UnitsUIContainer
             GameObject unitUIItem = Instantiate(unitItemUIPrefab, unitsContainer.transform);
             unitUIItem.GetComponentInChildren<Image>().sprite = unit.character.defaultSprite;
             Button unitItemButton = unitUIItem.GetComponent<Button>();
-            unitItemButton.onClick.AddListener(() => SelectUnit(unit, unitItemButton.gameObject));
+            unitItemButton.onClick.AddListener(() => SelectUnit(unit, unitUIItem));
             if (unitPopulator != null)
             {
                 unitPopulator.Populate(unit, unitUIItem);
@@ -26,8 +26,8 @@ public class LineUpUnitsUIContainer : UnitsUIContainer
 
     public override void SelectUnit(Unit unit, GameObject selector)
     {
-        Button unitItemButton = selector.GetComponent<Button>();
         OnUnitSelected.Invoke(unit);
+        Button unitItemButton = selector.GetComponent<Button>();
         unitItemButton.interactable = false;
         SetLocks();
     }

--- a/client/Assets/Scripts/Lineup/LineupManager.cs
+++ b/client/Assets/Scripts/Lineup/LineupManager.cs
@@ -54,9 +54,9 @@ public class LineupManager : MonoBehaviour, IUnitPopulator
 
     private void AddUnitToLineup(Unit unit)
     {
-        UnitPosition unitPosition = playerUnitPositions.First(unitPosition => !unitPosition.IsOccupied);
+        UnitPosition unitPosition = playerUnitPositions.FirstOrDefault(unitPosition => !unitPosition.IsOccupied);
 
-        if(unitPosition)
+        if(unitPosition != null)
         {
             int slot = Array.FindIndex(playerUnitPositions, up => !up.IsOccupied);
             unit.selected = true;

--- a/client/Assets/Scripts/Shared/UnitItemUI.cs
+++ b/client/Assets/Scripts/Shared/UnitItemUI.cs
@@ -13,7 +13,6 @@ public class UnitItemUI : MonoBehaviour {
     private Image selectedChampionMark;
     [SerializeField]
     private Image lockedOverlay;
-
     [SerializeField]
     private TextMeshProUGUI level;
 
@@ -35,7 +34,7 @@ public class UnitItemUI : MonoBehaviour {
 
     public void SetLocked(bool locked) {
         lockedOverlay.gameObject.SetActive(locked);
-        if (locked) {
+        if (locked || IsSelected()) {
             GetComponent<Button>().interactable = false;
         } else {
             GetComponent<Button>().interactable = true;


### PR DESCRIPTION
Closes #172 

## Motivation

The player shouldn't be able to select the same unit more than one time.

## Summary of changes

When selecting and unselecting units a logic is run to check if the units should be locked, this was overwriting the interactable property of the units button to select them, since it wasn't taking into consideration whether the unit was already selected, this PR changes that and takes into consideration whether the unit is selected inside the SetLocked method.

## How has this been tested?

Try to select the same unit in the lineup screen multiple times, when it's already selected (with the green tick before the icon), it shouldn't be possible to add another copy to the squad.

## Checklist
- [X] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
