### PR TITLE
Deselect units in ascension screen

### DIFF
--- a/client/Assets/Scripts/Ascension/AscensionManager.cs
+++ b/client/Assets/Scripts/Ascension/AscensionManager.cs
@@ -54,7 +54,7 @@ public class AscensionManager : MonoBehaviour, IUnitPopulator
         }
         else
         {
-            RemoveUnitFromContainer(unit);
+            RemoveUnitFromContainer();
             unitsContainer.SetUnitsLock(unit.character.faction, false);
             fusionButton.gameObject.SetActive(false);
         }
@@ -64,14 +64,14 @@ public class AscensionManager : MonoBehaviour, IUnitPopulator
     {
         if (modelContainer.transform.childCount > 0)
         {
-            RemoveUnitFromContainer(unit);
+            RemoveUnitFromContainer();
         }
         Instantiate(unit.character.prefab, modelContainer.transform);
         characterNameContainer.GetComponentInChildren<TextMeshProUGUI>().text = unit.character.name + "\n Rank: " + unit.rank.ToString();
         characterNameContainer.SetActive(true);
     }
 
-    private void RemoveUnitFromContainer(Unit unit)
+    private void RemoveUnitFromContainer()
     {
         Destroy(modelContainer.transform.GetChild(0).gameObject);
         characterNameContainer.SetActive(false);
@@ -80,6 +80,7 @@ public class AscensionManager : MonoBehaviour, IUnitPopulator
     public void Fusion() {
         // globalUserData.User.FuseUnits(selectedUnits);
         Debug.LogError("Fusion not yet connected to backend");
+        RemoveUnitFromContainer();
         this.unitsContainer.Populate(globalUserData.Units, this);
         selectedUnits.Clear();
         fusionButton.gameObject.SetActive(false);

--- a/client/Assets/Scripts/Shared/UnitItemUI.cs
+++ b/client/Assets/Scripts/Shared/UnitItemUI.cs
@@ -26,7 +26,6 @@ public class UnitItemUI : MonoBehaviour {
 
     public void SetSelectedChampionMark(bool selected) {
         selectedChampionMark.gameObject.SetActive(selected);
-        GetComponent<Button>().interactable = !selected;
     }
 
     public bool IsSelected() {


### PR DESCRIPTION
Closes #184 

Before this the player wasn't able to deselect units in the ascension screen, forcing him to return to the over-world and re enter the ascension screen, now by touching on an already selected unit's icon this unit will be unselected. Also when the fusion is performed (confirming the popup) the model and information about the selected unit will also disappear, since the there will be no units selected.

## Checklist
- [X] I have tested the changes locally.
- [X] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
