### PR TITLE
Minor QoL improvements

### DIFF
--- a/client/Assets/Prefabs/Camera/TitleScreenCameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/TitleScreenCameraUI.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 9118101695640014375}
   - component: {fileID: 2715235285887230562}
   - component: {fileID: 7406126844779593833}
+  - component: {fileID: 6366927080075148121}
   m_Layer: 5
   m_Name: Version
   m_TagString: Untagged
@@ -136,6 +137,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6366927080075148121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270936414570726327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3521625ad4bd54c91b248d4743e13b03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: {fileID: 7406126844779593833}
 --- !u!1 &524417006874143901
 GameObject:
   m_ObjectHideFlags: 0
@@ -567,6 +581,7 @@ MonoBehaviour:
   MouseMode: 1
   isBackButton: 0
   executeRelease: 0
+  listElement: 0
 --- !u!1 &904415009785142596
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Scripts/SelectServerIP.cs
+++ b/client/Assets/Scripts/SelectServerIP.cs
@@ -15,8 +15,13 @@ public class SelectServerIP : MonoBehaviour
     public static string serverNameString;
 
     // TODO: This should be a config file
-    private const string _defaultServerName = "BRAZIL";
-    private const string _defaultServerIp = "brazil-testing.curseofmirra.com";
+    #if UNITY_EDITOR
+        private const string _defaultServerName = "LOCALHOST";
+        private const string _defaultServerIp = "localhost";
+    #else
+        private const string _defaultServerName = "BRAZIL";
+        private const string _defaultServerIp = "brazil-testing.curseofmirra.com";
+    #endif
 
     public void SetServerIp()
     {

--- a/client/Assets/Scripts/VersionDisplay.cs
+++ b/client/Assets/Scripts/VersionDisplay.cs
@@ -1,0 +1,16 @@
+using TMPro;
+using UnityEngine;
+using System.Reflection;
+using System.IO;
+
+public class VersionDisplay : MonoBehaviour
+{
+    [SerializeField]
+    TextMeshProUGUI version;
+
+    void Start()
+    {
+        string buildTimestamp = new FileInfo(Assembly.GetExecutingAssembly().Location).LastWriteTimeUtc.ToString("yyyyMMddHHmmss");
+        version.text = "Version: " + buildTimestamp + "-pre-alpha";
+    }
+}

--- a/client/Assets/Scripts/VersionDisplay.cs.meta
+++ b/client/Assets/Scripts/VersionDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3521625ad4bd54c91b248d4743e13b03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR introduces 2 changes that need to be tested in builds which means I can't test them and need help :D 

- Version number, text showing version should be something like `20240313201905-pre-alpha` which is roughly `year month day hour minute second`. We could simplify a bit of the text, so feel free to comment on it. Also, we could expand the space for the text
- Default server, when building in Unity editor it should default to localhost, but when making builds they should default to Brazil server (was the current setup)
