### PR TITLE
Fix select locked levels and boss level always locked

### DIFF
--- a/client/Assets/Prefabs/Level/Level_1-1.prefab
+++ b/client/Assets/Prefabs/Level/Level_1-1.prefab
@@ -241,7 +241,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3525489903353544345}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 

--- a/client/Assets/Scripts/Campaign/CampaignLevelIndicator.cs
+++ b/client/Assets/Scripts/Campaign/CampaignLevelIndicator.cs
@@ -24,6 +24,7 @@ public class CampaignLevelIndicator : MonoBehaviour
                 break;
             case LevelProgress.Status.Unlocked:
 				lockObject.SetActive(false);
+				GetComponent<Button>().enabled = true;
                 break;
             case LevelProgress.Status.Completed:
                 completedCrossObject.SetActive(true);

--- a/client/Assets/Scripts/Campaign/CampaignLevelsManager.cs
+++ b/client/Assets/Scripts/Campaign/CampaignLevelsManager.cs
@@ -21,7 +21,7 @@ public class CampaignLevelsManager : MonoBehaviour
 			throw new Exception("The number of levels brought from the backend doesn't match with the number of levels on that campaign prefab.");
 		}
 
-        for(int levelIndex = 1; levelIndex < levelsData.Count; levelIndex++) {
+        for(int levelIndex = 1; levelIndex < levelsData.Count + 1; levelIndex++) {
             levelIndicators[levelIndex - 1].levelData = levelsData[levelIndex - 1];
 
 			if(levelIndex < levelsData.Count) {


### PR DESCRIPTION
Closes #345 

## Motivation

The boss level (last level of the campaign) was always locked and the user was able to select the locked levels of the campaign to battle.

## Summary of changes

- Fix and index in CampaignsLevelManager.cs so that the last level of the campaign isn't always locked anymore.
- Disable the button in the campaign level indicator prefab so they aren't selecteable by default, the current level of the user enables this component.

## How has this been tested?

- Inside a campaign select the locked levels and make sure the "START" button doesn't show up.
- Unlock the last level of a campaign by normal means, check the level indicator doesn't have the lock and can be played normally, when won, it must unlock the next campaign.