### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: generate-protos
 
-generate-protos: 
-    protoc --csharp_out=./ messages.proto \
-    mv Messages.cs client/Assets/Scripts/Messages.pb.cs
+generate-protos:
+	protoc --csharp_out=./ gateway.proto
+	mv Gateway.cs client/Assets/Scripts/Protobuf/Gateway.pb.cs


### PR DESCRIPTION
Closes #371 

## Motivation

The Makefile wasn't working, the client only uses it to generate the protobuf classes, but still is a nice quality of life feature for developers, especially if they are unfamiliar with the project.

## Summary of changes

- Changed the paths on the Makefile which were outdated.
- Fixed the indentation, replacing spaces with tabs, which throw an error: "missing separator. Stop.".

## How to test

Make a change to the gateway.proto file on the root of the project, run the `make generate-protos` command and then verify that the respective change has been made, keep in mind if a modification or deletion is made some scripts will break. To check this you have to look in scripts that use the protobuf class, since the `Gateway.pb.cs` script, where the change is actually made, is not human readable.

E.g. in my case I changed the type of the `id` field of the `BattleUnit` message, in line 347 from `string` to `int32`, and it broke the `BattleManager.cs` script.