### PR TITLE
Battle with Dynamic Number of Units

### DIFF
--- a/client/Assets/Scenes/Lineup.unity
+++ b/client/Assets/Scenes/Lineup.unity
@@ -2568,8 +2568,32 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Interactable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
       propertyPath: m_TargetGraphic
       value: 
+      objectReference: {fileID: 1297184652}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Colors.m_ColorMultiplier
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Colors.m_DisabledColor.a
+      value: 0.5372549
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Colors.m_DisabledColor.b
+      value: 0.5176471
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Colors.m_DisabledColor.g
+      value: 0.5176471
+      objectReference: {fileID: 0}
+    - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+      propertyPath: m_Colors.m_DisabledColor.r
+      value: 0.5176471
       objectReference: {fileID: 0}
     - target: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -2618,6 +2642,28 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8811879872254460244, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
   m_PrefabInstance: {fileID: 1297184650}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1297184652 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8811879872254460240, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+  m_PrefabInstance: {fileID: 1297184650}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1297184653 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8811879872254460245, guid: b00fb03a1acae45d3aefc817547b517c, type: 3}
+  m_PrefabInstance: {fileID: 1297184650}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1389084732
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3225,6 +3271,7 @@ MonoBehaviour:
   - {fileID: 1174301470}
   - {fileID: 1034271286}
   - {fileID: 917207515}
+  battleButton: {fileID: 1297184653}
 --- !u!4 &1606196172
 Transform:
   m_ObjectHideFlags: 0

--- a/client/Assets/Scripts/Battle/BattleManager.cs
+++ b/client/Assets/Scripts/Battle/BattleManager.cs
@@ -85,7 +85,7 @@ public class BattleManager : MonoBehaviour
 	{
 		foreach (var step in steps)
 		{
-			yield return new WaitForSeconds(.04f);
+			yield return new WaitForSeconds(.4f);
 
 			ProcessEffectTriggers(step.Actions);
 			ProcessHitsAndMisses(step.Actions);

--- a/client/Assets/Scripts/Battle/BattleManager.cs
+++ b/client/Assets/Scripts/Battle/BattleManager.cs
@@ -71,9 +71,10 @@ public class BattleManager : MonoBehaviour
 
 	private void SetUpInitialState(Protobuf.Messages.BattleResult battleResult)
 	{
+
 		foreach (var unit in battleResult.InitialState.Units)
 		{
-			BattleUnit battleUnit = battleUnitsUI.Single(battleUnit => battleUnit.SelectedUnit.id == unit.Id);
+			BattleUnit battleUnit = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Single(battleUnit => battleUnit.SelectedUnit.id == unit.Id);
 			battleUnit.gameObject.SetActive(true);
 			battleUnit.MaxHealth = unit.Health;
 			battleUnit.CurrentHealth = unit.Health;
@@ -84,7 +85,7 @@ public class BattleManager : MonoBehaviour
 	{
 		foreach (var step in steps)
 		{
-			yield return new WaitForSeconds(.4f);
+			yield return new WaitForSeconds(.04f);
 
 			ProcessEffectTriggers(step.Actions);
 			ProcessHitsAndMisses(step.Actions);
@@ -98,7 +99,7 @@ public class BattleManager : MonoBehaviour
 				switch (action.ActionTypeCase)
 				{
 					case Protobuf.Messages.Action.ActionTypeOneofCase.Death:
-						battleUnitsUI.Single(unit => unit.SelectedUnit.id == action.Death.UnitId).DeathFeedback();
+						battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Single(unit => unit.SelectedUnit.id == action.Death.UnitId).DeathFeedback();
 						break;
 					default:
 						break;
@@ -150,8 +151,8 @@ public class BattleManager : MonoBehaviour
 
 		foreach (Protobuf.Messages.Action action in effectTriggerActions)
 		{
-			BattleUnit casterUnit = battleUnitsUI.Single(battleUnit => battleUnit.SelectedUnit.id == action.SkillAction.CasterId);
-			List<BattleUnit> targetUnits = battleUnitsUI.Where(unit => action.SkillAction.TargetIds.Contains(unit.SelectedUnit.id)).ToList();
+			BattleUnit casterUnit = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Single(battleUnit => battleUnit.SelectedUnit.id == action.SkillAction.CasterId);
+			List<BattleUnit> targetUnits = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Where(unit => action.SkillAction.TargetIds.Contains(unit.SelectedUnit.id)).ToList();
 
 			foreach (BattleUnit targetUnit in targetUnits)
 			{
@@ -169,8 +170,8 @@ public class BattleManager : MonoBehaviour
 
 		foreach (Protobuf.Messages.Action action in hitAndMissActions)
 		{
-			BattleUnit casterUnit = battleUnitsUI.Single(battleUnit => battleUnit.SelectedUnit.id == action.SkillAction.CasterId);
-			List<BattleUnit> targetUnits = battleUnitsUI.Where(unit => action.SkillAction.TargetIds.Contains(unit.SelectedUnit.id)).ToList();
+			BattleUnit casterUnit = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Single(battleUnit => battleUnit.SelectedUnit.id == action.SkillAction.CasterId);
+			List<BattleUnit> targetUnits = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Where(unit => action.SkillAction.TargetIds.Contains(unit.SelectedUnit.id)).ToList();
 
 			foreach (BattleUnit targetUnit in targetUnits)
 			{
@@ -188,7 +189,7 @@ public class BattleManager : MonoBehaviour
 
 		foreach (Protobuf.Messages.Action action in executionReceivedActions)
 		{
-			BattleUnit target = battleUnitsUI.Single(unit => unit.SelectedUnit.id == action.ExecutionReceived.TargetId);
+			BattleUnit target = battleUnitsUI.Where(battleUnit => battleUnit.SelectedUnit != null).Single(unit => unit.SelectedUnit.id == action.ExecutionReceived.TargetId);
 			var statAffected = action.ExecutionReceived.StatAffected;
 			switch (statAffected.Stat)
 			{

--- a/client/Assets/Scripts/Lineup/LineupManager.cs
+++ b/client/Assets/Scripts/Lineup/LineupManager.cs
@@ -19,6 +19,9 @@ public class LineupManager : MonoBehaviour, IUnitPopulator
     [SerializeField]
     UnitPosition[] opponentUnitPositions;
 
+	[SerializeField]
+	Button battleButton;
+
     void Start()
     {
         StartCoroutine(GetUser());
@@ -46,6 +49,10 @@ public class LineupManager : MonoBehaviour, IUnitPopulator
             UnitPosition unitPosition = unitPositions[unit.slot.Value - 1];
             unitPosition.SetUnit(unit, isPlayer);
             unitPosition.OnUnitRemoved += RemoveUnitFromLineup;
+
+			if(isPlayer) {
+				battleButton.interactable = true;
+			}
         }
     }
 
@@ -62,6 +69,7 @@ public class LineupManager : MonoBehaviour, IUnitPopulator
             unitPosition.OnUnitRemoved += RemoveUnitFromLineup;
             SocketConnection.Instance.SelectUnit(unit.id, GlobalUserData.Instance.User.id, slot);
             unitsContainer.SetUnitUIActiveById(unit.id, false);
+			battleButton.interactable = true;
         }
     }
 
@@ -73,6 +81,10 @@ public class LineupManager : MonoBehaviour, IUnitPopulator
         unit.slot = null;
         SocketConnection.Instance.UnselectUnit(unit.id, GlobalUserData.Instance.User.id);
         unitsContainer.SetUnitUIActiveById(unit.id, true);
+
+		if(!playerUnitPositions.Any(unit => unit.IsOccupied)) {
+			battleButton.interactable = false;
+		}
     }
 
     private bool CompareUnitId(UnitPosition unitPosition, Unit unit)


### PR DESCRIPTION
Closes #368 

## Motivation

If a battle was played fought with less than six units on either team, the client would break, this had to be fixed since the player could choose to fight with less than the max number of units, or maybe a level could have less than six, even if these weren't the cases, is allows for better manual testing of the application.

## Summary of changes

The problem lied on the `BattleManager.cs` script breaking since in certain points it searches through the collection of `BattleUnits` searching for one with certain unit `id`, this caused a Null Reference Exception since when less than twelve units in total started the battle some `BattleUnit` will have a null `selectedUnit` reference thus causing the exception when trying to access the `id` field of the unit.

To fix this, whenever a specific `BattleUnit` is searched by its unit's `id` an additional filtering is applied to look for the ones that have a `selectedUnit` assigned.

## How has this been tested?

Go to the lineup screen of a level and remove some of the units on your team, then let the fight the battle, it should play out as normal and don't break. The same should be done by removing some of the units of a level in the local backend, then fighting that level and checking nothing breaks, this could be done by getting the `level_id` of the level where you are going to test this, go to the unit's table and search for the ones with that `level_id` and delete one or more, then try to fight that level on the client, checking everything works as normal.