### PR TITLE
Rearrange Units in Battle

### DIFF
--- a/client/Assets/Prefabs/Lineup/UnitPosition.prefab
+++ b/client/Assets/Prefabs/Lineup/UnitPosition.prefab
@@ -1,171 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1298774226396644717
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6435257118427267529}
-  - component: {fileID: 7007868704140084435}
-  m_Layer: 5
-  m_Name: Model
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6435257118427267529
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1298774226396644717}
-  m_LocalRotation: {x: 0, y: 0.92387956, z: 0, w: 0.38268343}
-  m_LocalPosition: {x: 0, y: 0, z: 200}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5696561087525137316}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 135, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &7007868704140084435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1298774226396644717}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding: {x: 0, y: 0, z: 0, w: 0}
-  m_Softness: {x: 0, y: 0}
---- !u!1 &1475905543616670751
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5696561087525137316}
-  - component: {fileID: 5785244628437213844}
-  - component: {fileID: 9088345735996945260}
-  m_Layer: 5
-  m_Name: ModelCamera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5696561087525137316
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1475905543616670751}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6435257118427267529}
-  m_Father: {fileID: 8610322166662081407}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 3500, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!20 &5785244628437213844
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1475905543616670751}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0
-  far clip plane: 15
-  field of view: 60
-  orthographic: 1
-  orthographic size: 3.8
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 8400000, guid: ccb48642a18f846d1b49ac5199890205, type: 2}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!114 &9088345735996945260
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1475905543616670751}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 0
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 1
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
 --- !u!1 &7053750445632560982
 GameObject:
   m_ObjectHideFlags: 0
@@ -197,7 +31,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8610322166662081407}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -696,7 +530,7 @@ RectTransform:
   m_Children:
   - {fileID: 6371384973799118038}
   m_Father: {fileID: 8610322166662081407}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -814,7 +648,6 @@ RectTransform:
   m_Children:
   - {fileID: 8888682293298707751}
   - {fileID: 4910767040816234159}
-  - {fileID: 5696561087525137316}
   - {fileID: 8610322166391184613}
   - {fileID: 3014094729277823252}
   - {fileID: 2169300769376718971}

--- a/client/Assets/Scenes/Battle.unity
+++ b/client/Assets/Scenes/Battle.unity
@@ -715,7 +715,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -771,11 +771,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -294.37152
+      value: -200
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -325.00006
+      value: -500
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1108,7 +1108,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1176,11 +1176,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 319.3715
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -225.00006
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1458,7 +1458,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1545,7 +1545,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1601,11 +1601,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -194.37152
+      value: -350
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -147.00006
+      value: -180
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2222,7 +2222,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2309,7 +2309,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2377,11 +2377,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 344.3715
+      value: 325
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -125.00007
+      value: -380
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2548,7 +2548,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2635,7 +2635,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2703,11 +2703,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 144.37146
+      value: 230
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -226.00006
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3060,7 +3060,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3116,11 +3116,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -319.37152
+      value: -110
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -225.00006
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3161,7 +3161,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3548,7 +3548,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3604,11 +3604,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -144.37152
+      value: -230
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -228.00006
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3649,7 +3649,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3856,7 +3856,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3924,11 +3924,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 194.37149
+      value: 350
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -150.00006
+      value: -180
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3973,7 +3973,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4137,7 +4137,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -4193,11 +4193,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -94.37152
+      value: -85
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -325.00006
+      value: -350
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4337,7 +4337,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -4405,11 +4405,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 294.3715
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -325.00006
+      value: -500
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4818,7 +4818,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4889,7 +4889,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4960,7 +4960,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5484,7 +5484,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5552,11 +5552,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 94.37146
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -325.00006
+      value: -350
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5619,15 +5619,15 @@ RectTransform:
   m_GameObject: {fileID: 2011782927}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.53567994, y: 0.53567994, z: 0.53567994}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 442142762}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 2.0000103}
+  m_AnchoredPosition: {x: 0, y: 100}
   m_SizeDelta: {x: 4156, y: 4156}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2011782929
@@ -5693,7 +5693,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5749,11 +5749,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -344.37152
+      value: -325
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -125.00007
+      value: -380
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: a29b48d50dba94808bd22cb8f2c07121, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6012,7 +6012,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 3340029395093796300, guid: ecaf737f0b07146d69c6c5e29ea6bbfc, type: 3}
       propertyPath: m_LocalPosition.x

--- a/client/Assets/Scenes/Lineup.unity
+++ b/client/Assets/Scenes/Lineup.unity
@@ -328,11 +328,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -175
+      value: -300
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -300
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -514,11 +514,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 275
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -400
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -588,7 +588,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.05, y: 0.1}
-  m_AnchorMax: {x: 0.45, y: 0.9}
+  m_AnchorMax: {x: 0.45, y: 0.7}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0.5}
@@ -619,15 +619,15 @@ RectTransform:
   m_GameObject: {fileID: 248698612}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5361307, y: 0.5361307, z: 0.5361307}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 0.65, y: 0.65, z: 0.65}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1607100094}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 194}
+  m_AnchoredPosition: {x: 0, y: 400}
   m_SizeDelta: {x: 4156, y: 4156}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &248698614
@@ -825,11 +825,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 250
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -500
+      value: -220
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1249,11 +1249,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -275
+      value: -80
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -400
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1521,11 +1521,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -75
+      value: -55
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -500
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1743,11 +1743,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -250
+      value: -160
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -500
+      value: -220
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1936,11 +1936,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 75
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -500
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2250,11 +2250,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -125
+      value: -185
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -400
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2326,7 +2326,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.55, y: 0.1}
-  m_AnchorMax: {x: 0.95, y: 0.9}
+  m_AnchorMax: {x: 0.95, y: 0.7}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0.5}
@@ -2779,11 +2779,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -300
+      value: -275
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -300
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3090,11 +3090,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 300
+      value: 275
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -300
+      value: -150
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3929,11 +3929,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 125
+      value: 185
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -400
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4487,11 +4487,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 150
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -300
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8610322166662081407, guid: 5db8c2f8d25284f3d901292ba31f9692, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
Closes #397

## Motivation

The unit's positions in the lineup and battle screens didn't reflect the actual positions in the backend. Also units were clumped up together, making it difficult to understand what was happening in the battle.

## Summary of changes

Changed the order and positions of the units in the lineup and battle screens, also made the background bigger to match the space needed for the units.

## How has this been tested?

Check the battle runs like normal, with new positions for the units, them being more spaced out, also, check from the backend the slots of each unit in the battle and verify these match the client's positions as shown here or in the liked issue.

```
3
4	1		
5	2		
6	

```