### PR TITLE
Support multiple supercampaigns

### DIFF
--- a/client/Assets/Scenes/Overworld.unity
+++ b/client/Assets/Scenes/Overworld.unity
@@ -4510,7 +4510,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5680396890292483277, guid: c36f69f305d3c4336a02acc5a4050f98, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: ChangeToSceneWithDelay
+      value: ChangeToSuperCampaign
       objectReference: {fileID: 0}
     - target: {fileID: 5680396890292483277, guid: c36f69f305d3c4336a02acc5a4050f98, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -4526,7 +4526,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5680396890292483277, guid: c36f69f305d3c4336a02acc5a4050f98, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
-      value: CampaignsMap
+      value: Main Campaign
       objectReference: {fileID: 0}
     - target: {fileID: 5680396890292483277, guid: c36f69f305d3c4336a02acc5a4050f98, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -11,210 +11,156 @@ using UnityEngine;
 
 public class SocketConnection : MonoBehaviour
 {
-    public class SocketConnection : MonoBehaviour
+    WebSocket ws;
+
+    public static SocketConnection Instance;
+
+    public bool connected = false;
+
+    private WebSocketMessageEventHandler currentMessageHandler;
+
+    async void Start()
     {
-        WebSocket ws;
+        Init();
+    }
 
-        public static SocketConnection Instance;
+    public void Init()
+    {
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
 
-        public bool connected = false;
-
-        private WebSocketMessageEventHandler currentMessageHandler;
-
-        async void Start()
+        if (!connected)
         {
-            Init();
+            connected = true;
+            ConnectToSession();
         }
+    }
 
-        public void Init()
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            public void Init()
-            {
-                Instance = this;
-                DontDestroyOnLoad(gameObject);
-
-                if (!connected)
-                {
-                    connected = true;
-                    ConnectToSession();
-                }
-            }
-            if (!connected)
-            {
-                connected = true;
-                ConnectToSession();
-            }
-        }
-
-        void Update()
-        void Update()
-        {
+    void Update()
+    {
 #if !UNITY_WEBGL || UNITY_EDITOR
+        if (ws != null)
+        {
+            ws.DispatchMessageQueue();
+        }
+#endif
+    }
+
+    private async void OnApplicationQuit()
+    {
+        await this.CloseConnection();
+    }
+
+    private void ConnectToSession()
+    {
+        string url = $"{ServerSelect.Domain}/2";
+        ws = new WebSocket(url);
+        ws.OnMessage += OnWebSocketMessage;
+        ws.OnClose += OnWebsocketClose;
+        ws.OnOpen += () =>
+        {
+            GetUserAndContinue();
+        };
+        ws.OnError += (e) =>
+        {
+            Debug.LogError("Received error: " + e);
+        };
+        ws.Connect();
+    }
+
+    private void OnWebsocketClose(WebSocketCloseCode closeCode)
+    {
+        if (closeCode != WebSocketCloseCode.Normal)
+        {
+            // Errors.Instance.HandleNetworkError(connectionTitle, connectionDescription);
+            Debug.LogError("Your connection to the server has been lost.");
+        }
+        else
+        {
+            Debug.Log("ServerConnection websocket closed normally.");
+        }
+    }
+
+    private void SendWebSocketMessage<T>(IMessage<T> message)
+        where T : IMessage<T>
+    {
+        using (var stream = new MemoryStream())
+        {
+            message.WriteTo(stream);
+            var msg = stream.ToArray();
+
             if (ws != null)
             {
-                ws.DispatchMessageQueue();
+                ws.Send(msg);
             }
-#endif
+        }
+    }
+
+    public async Task CloseConnection()
+    {
+        if (connected && this.ws != null)
+        {
+            await this.ws.Close();
+            connected = false;
+        }
+    }
+
+    private void OnWebSocketMessage(byte[] data)
+    {
+        try
+        {
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            switch (webSocketResponse.ResponseTypeCase)
+            {
+                case WebSocketResponse.ResponseTypeOneofCase.Error:
+                    Debug.Log(webSocketResponse.Error.Reason);
+                    break;
+                // Since the response of type Unit isn't used for anything there isn't a specific handler for it, it is caught here so it doesn't log any confusing messages
+                case WebSocketResponse.ResponseTypeOneofCase.Unit:
+                    break;
+                default:
+                    Debug.Log("Request case not handled");
+                    break;
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("InvalidProtocolBufferException: " + e);
+        }
+    }
+
+    private User CreateUserFromData(Protobuf.Messages.User user, List<Character> availableCharacters)
+    {
+        List<Unit> units = CreateUnitsFromData(user.Units, availableCharacters);
+        List<Item> items = new List<Item>();
+
+        foreach (var userItem in user.Items)
+        {
+            items.Add(CreateItemFromData(userItem));
         }
 
-        private async void OnApplicationQuit()
-        {
-            await this.CloseConnection();
-        }
+        Dictionary<Currency, int> currencies = new Dictionary<Currency, int>();
 
-        private void ConnectToSession()
+        foreach (var currency in user.Currencies)
         {
-            string url = $"{ServerSelect.Domain}/2";
-            string url = $"{ServerSelect.Domain}/2";
-            ws = new WebSocket(url);
-            ws.OnMessage += OnWebSocketMessage;
-            ws.OnClose += OnWebsocketClose;
-            ws.OnOpen += () =>
+            if (Enum.TryParse<Currency>(currency.Currency.Name.Replace(" ", ""), out Currency currencyValue))
             {
-                GetUserAndContinue();
-            };
-            ws.OnError += (e) =>
-            {
-                Debug.LogError("Received error: " + e);
-            };
-            ws.Connect();
-        }
-
-        private void OnWebsocketClose(WebSocketCloseCode closeCode)
-        {
-            if (closeCode != WebSocketCloseCode.Normal)
-            {
-                // Errors.Instance.HandleNetworkError(connectionTitle, connectionDescription);
-                Debug.LogError("Your connection to the server has been lost.");
+                currencies.Add(currencyValue, (int)currency.Amount);
             }
             else
             {
-                Debug.Log("ServerConnection websocket closed normally.");
+                Debug.LogError($"Currency brought from the backend not found in client: {currency.Currency.Name}");
             }
         }
 
-        private void SendWebSocketMessage<T>(IMessage<T> message)
-            where T : IMessage<T>
+        KalineTreeLevel kalineTreeLevel = new KalineTreeLevel
         {
-            using (var stream = new MemoryStream())
-            {
-                message.WriteTo(stream);
-                var msg = stream.ToArray();
+            level = (int)user.KalineTreeLevel.Level,
+            goldLevelUpCost = ((int)user.KalineTreeLevel.GoldLevelUpCost),
+            fertilizerLevelUpCost = ((int)user.KalineTreeLevel.FertilizerLevelUpCost),
+            afkRewardRates = user.KalineTreeLevel.AfkRewardRates.Select(afkRewardRate => CreateAfkRewardRateFromData(afkRewardRate)).ToList()
+        };
 
-                if (ws != null)
-                {
-                    if (ws != null)
-                    {
-                        ws.Send(msg);
-                    }
-                }
-            }
-
-            public async Task CloseConnection()
-            {
-                if (connected && this.ws != null)
-                {
-                    await this.ws.Close();
-                    connected = false;
-                }
-            }
-
-            public async Task CloseConnection()
-            {
-                if (connected && this.ws != null)
-                {
-                    await this.ws.Close();
-                    connected = false;
-                }
-            }
-
-            private void OnWebSocketMessage(byte[] data)
-            {
-                try
-                {
-                    WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                    switch (webSocketResponse.ResponseTypeCase)
-                    {
-                        case WebSocketResponse.ResponseTypeOneofCase.Error:
-                            Debug.Log(webSocketResponse.Error.Reason);
-                            break;
-                        // Since the response of type Unit isn't used for anything there isn't a specific handler for it, it is caught here so it doesn't log any confusing messages
-                        case WebSocketResponse.ResponseTypeOneofCase.Unit:
-                            break;
-                        default:
-                            Debug.Log("Request case not handled");
-                            break;
-                    }
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError("InvalidProtocolBufferException: " + e);
-                }
-            }
-
-            private User CreateUserFromData(Protobuf.Messages.User user, List<Character> availableCharacters)
-            {
-                List<Unit> units = CreateUnitsFromData(user.Units, availableCharacters);
-                List<Item> items = new List<Item>();
-                private User CreateUserFromData(Protobuf.Messages.User user, List<Character> availableCharacters)
-                {
-                    List<Unit> units = CreateUnitsFromData(user.Units, availableCharacters);
-                    List<Item> items = new List<Item>();
-
-                    foreach (var userItem in user.Items)
-                    {
-                        items.Add(CreateItemFromData(userItem));
-                    }
-                    foreach (var userItem in user.Items)
-                    {
-                        items.Add(CreateItemFromData(userItem));
-                    }
-
-                    Dictionary<Currency, int> currencies = new Dictionary<Currency, int>();
-                    Dictionary<Currency, int> currencies = new Dictionary<Currency, int>();
-
-                    foreach (var currency in user.Currencies)
-                    {
-                        if (Enum.TryParse<Currency>(currency.Currency.Name.Replace(" ", ""), out Currency currencyValue))
-                        {
-                            currencies.Add(currencyValue, (int)currency.Amount);
-                        }
-                        else
-                        {
-                            Debug.LogError($"Currency brought from the backend not found in client: {currency.Currency.Name}");
-                        }
-                    }
-                    foreach (var currency in user.Currencies)
-                    {
-                        if (Enum.TryParse<Currency>(currency.Currency.Name.Replace(" ", ""), out Currency currencyValue))
-                        {
-                            currencies.Add(currencyValue, (int)currency.Amount);
-                        }
-                        else
-                        {
-                            Debug.LogError($"Currency brought from the backend not found in client: {currency.Currency.Name}");
-                        }
-                    }
-
-                    KalineTreeLevel kalineTreeLevel = new KalineTreeLevel
-                    {
-                        level = (int)user.KalineTreeLevel.Level,
-                        goldLevelUpCost = ((int)user.KalineTreeLevel.GoldLevelUpCost),
-                        fertilizerLevelUpCost = ((int)user.KalineTreeLevel.FertilizerLevelUpCost),
-                        afkRewardRates = user.KalineTreeLevel.AfkRewardRates.Select(afkRewardRate => CreateAfkRewardRateFromData(afkRewardRate)).ToList()
-                    };
-
-                    return new User
-                    {
-                        id = user.Id,
-                        username = user.Username,
-                        units = units,
-                        items = items,
-                        currencies = currencies,
-                        level = (int)user.Level,
-                        experience = (int)user.Experience,
         return new User
         {
             id = user.Id,
@@ -226,292 +172,186 @@ public class SocketConnection : MonoBehaviour
             experience = (int)user.Experience,
             kalineTreeLevel = kalineTreeLevel
         };
-                }
-                private Item CreateItemFromData(Protobuf.Messages.Item itemData)
-                {
-                };
-            }
-            private Item CreateItemFromData(Protobuf.Messages.Item itemData)
-            {
-                return new Item
-                {
-                    id = itemData.Id,
-                    level = (int)itemData.Level,
-                    userId = itemData.UserId,
-                    unitId = itemData.UnitId,
-                    template = GlobalUserData.Instance.AvailableItemTemplates.Find(itemtemplate => itemtemplate.name.ToLower() == itemData.Template.Name.ToLower())
-                };
-            }
-
-            private AfkRewardRate CreateAfkRewardRateFromData(Protobuf.Messages.AfkRewardRate afkRewardRateData)
-            {
-                return new AfkRewardRate
-                {
-                    kalineTreeLevelId = afkRewardRateData.KalineTreeLevelId,
-                    currency = Enum.Parse<Currency>(afkRewardRateData.Currency.Name.Replace(" ", "")),
-                    rate = afkRewardRateData.Rate
-                };
-            }
-
-            private Unit CreateUnitFromData(Protobuf.Messages.Unit unitData, List<Character> availableCharacters)
-            {
-                if (!availableCharacters.Any(character => character.name.ToLower() == unitData.Character.Name.ToLower()))
-                {
-                    Debug.Log($"Character not found in available characters: {unitData.Character.Name}");
-                    return null;
-                }
-                private Unit CreateUnitFromData(Protobuf.Messages.Unit unitData, List<Character> availableCharacters)
-                {
-                    if (!availableCharacters.Any(character => character.name.ToLower() == unitData.Character.Name.ToLower()))
-                    {
-                        Debug.Log($"Character not found in available characters: {unitData.Character.Name}");
-                        return null;
-                    }
-
-                    return new Unit
-                    {
-                        id = unitData.Id,
-                        // tier = (int)unitData.Tier,
-                        character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
-                        rank = (Rank)unitData.Rank,
-                        level = (int)unitData.Level,
-                        slot = (int?)unitData.Slot,
-                        selected = unitData.Selected
-                    };
-                }
-                return new Unit
-                {
-                    id = unitData.Id,
-                    // tier = (int)unitData.Tier,
-                    character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
-                    rank = (Rank)unitData.Rank,
-                    level = (int)unitData.Level,
-                    slot = (int?)unitData.Slot,
-                    selected = unitData.Selected
-                };
-            }
-
-            private List<Unit> CreateUnitsFromData(IEnumerable<Protobuf.Messages.Unit> unitsData, List<Character> availableCharacters)
-            {
-                List<Unit> createdUnits = new List<Unit>();
-                {
-                    List<Unit> createdUnits = new List<Unit>();
-
-                    foreach (var unitData in unitsData)
-                    {
-                        Unit unit = CreateUnitFromData(unitData, availableCharacters);
-
-                        if (unit != null)
-                        {
-                            createdUnits.Add(unit);
-                        }
-                    }
-                    foreach (var unitData in unitsData)
-                    {
-                        Unit unit = CreateUnitFromData(unitData, availableCharacters);
-
-                        if (unit != null)
-                        {
-                            createdUnits.Add(unit);
-                        }
-                    }
-
-                    return createdUnits;
-                }
-                return createdUnits;
-            }
-
-            private List<Campaign> ParseCampaignsFromResponse(Protobuf.Messages.Campaigns campaignsData, string superCampaignName, List<Character> availableCharacters)
-            {
-                List<(string superCampaignName, string campaignId, string levelId)> userCampaignsProgress = GlobalUserData.Instance.User.campaignsProgresses;
-                List<Campaign> campaigns = new List<Campaign>();
-                LevelProgress.Status campaignStatus = LevelProgress.Status.Completed;
-                LevelProgress.Status campaignStatus = LevelProgress.Status.Completed;
-
-                // Filter campaigns by supercampaign name
-                var superCampaignCampaigns = campaignsData.Campaigns_.Where(campaign => campaign.SuperCampaignName == superCampaignName).ToList();
-
-                foreach (Protobuf.Messages.Campaign campaignData in superCampaignCampaigns)
-                {
-                    LevelProgress.Status levelStatus = LevelProgress.Status.Completed;
-                    LevelProgress.Status levelStatus = LevelProgress.Status.Completed;
-                    List<LevelData> levels = new List<LevelData>();
-
-                    foreach (Protobuf.Messages.Level level in campaignData.Levels.OrderBy(level => level.LevelNumber))
-
-                        foreach (Protobuf.Messages.Level level in campaignData.Levels.OrderBy(level => level.LevelNumber))
-                        {
-                            List<Unit> levelUnits = CreateUnitsFromData(level.Units, availableCharacters);
-                            List<Unit> levelUnits = CreateUnitsFromData(level.Units, availableCharacters);
-
-                            levelStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id && cp.levelId == level.Id) ? LevelProgress.Status.Unlocked : levelStatus;
-                            levelStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id && cp.levelId == level.Id) ? LevelProgress.Status.Unlocked : levelStatus;
-
-                            levels.Add(new LevelData
-                            {
-                                id = level.Id,
-                                levelNumber = (int)level.LevelNumber,
-                                campaignId = level.CampaignId,
-                                units = levelUnits,
-                                rewards = GetLevelCurrencyRewards(level),
-                                rewards = GetLevelCurrencyRewards(level),
-                                status = levelStatus
-                            });
-
-
-                            if (levelStatus == LevelProgress.Status.Unlocked)
-                            {
-                                levelStatus = LevelProgress.Status.Locked;
-                            }
-
-                            if (levelStatus == LevelProgress.Status.Unlocked)
-                            {
-                                levelStatus = LevelProgress.Status.Locked;
-                            }
-                        }
-
-                    campaignStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id) ? LevelProgress.Status.Unlocked : campaignStatus;
-                    campaignStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id) ? LevelProgress.Status.Unlocked : campaignStatus;
-
-                    campaigns.Add(new Campaign
-                    {
-                        campaignId = campaignData.Id,
-                        campaignNumber = (int)campaignData.CampaignNumber,
-                        campaignId = campaignData.Id,
-                        campaignNumber = (int)campaignData.CampaignNumber,
-                        status = campaignStatus,
-                        levels = levels
-                    });
-
-                    if (campaignStatus == LevelProgress.Status.Unlocked)
-                    {
-                        campaignStatus = LevelProgress.Status.Locked;
-                    }
-                    if (campaignStatus == LevelProgress.Status.Unlocked)
-                    {
-                        campaignStatus = LevelProgress.Status.Locked;
-                    }
-                }
-
-                return campaigns;
-            }
-
-            // Better name for this method?
-            // This should be refactored, assigning player prefs should not be handled here
-            public void GetUserAndContinue()
-            {
-                string userId = PlayerPrefs.GetString($"userId_{ServerSelect.Name}");
-                if (String.IsNullOrEmpty(userId))
-                {
-                    string userName = $"testUser-{Guid.NewGuid()}";
-                    Debug.Log($"No user in player prefs, creating user with username: \"{userName}\"");
-                    CreateUser(userName, (user) =>
-                    {
-                        GetCampaignProgresses(user.id, (progresses) =>
-                        {
-                            user.campaignsProgresses = progresses;
-                        });
-                        PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-                        GlobalUserData.Instance.User = user;
-                        Debug.Log("User created correctly");
-                    });
-                }
-                else
-                {
-                    Debug.Log($"Found userid: \"{userId}\" in playerprefs, getting the user");
-                    GetUser(userId, (user) =>
-                    {
-                        GetCampaignProgresses(user.id, (progresses) =>
-                        {
-                            user.campaignsProgresses = progresses;
-                        });
-                        PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-                        GlobalUserData.Instance.User = user;
-                    });
-                }
-                string userId = PlayerPrefs.GetString($"userId_{ServerSelect.Name}");
-                if (String.IsNullOrEmpty(userId))
-                {
-                    string userName = $"testUser-{Guid.NewGuid()}";
-                    Debug.Log($"No user in player prefs, creating user with username: \"{userName}\"");
-                    CreateUser(userName, (user) =>
-                    {
-                        GetCampaignProgresses(user.id, (progresses) =>
-                        {
-                            user.campaignsProgresses = progresses;
-                        });
-                        PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-                        GlobalUserData.Instance.User = user;
-                        Debug.Log("User created correctly");
-                    });
-                }
-                else
-                {
-                    Debug.Log($"Found userid: \"{userId}\" in playerprefs, getting the user");
-                    GetUser(userId, (user) =>
-                    {
-                        GetCampaignProgresses(user.id, (progresses) =>
-                        {
-                            user.campaignsProgresses = progresses;
-                        });
-                        PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-                        GlobalUserData.Instance.User = user;
-                    });
-                }
-            }
-
-            public void GetUser(string userId, Action<User> onGetUserDataReceived)
-            {
-                try
-                {
-                    GetUser getUserRequest = new GetUser
-                    {
-                        UserId = userId
-                    };
-                    WebSocketRequest request = new WebSocketRequest
-                    {
-                        GetUser = getUserRequest
-                    };
-                    currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
-                    ws.OnMessage += currentMessageHandler;
-                    ws.OnMessage -= OnWebSocketMessage;
-                    SendWebSocketMessage(request);
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogError(ex.Message);
-                }
-                try
-                {
-                    GetUser getUserRequest = new GetUser
-                    {
-                        UserId = userId
-                    };
-                    WebSocketRequest request = new WebSocketRequest
-                    {
-                        GetUser = getUserRequest
-                    };
-                    currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
-                    ws.OnMessage += currentMessageHandler;
-                    ws.OnMessage -= OnWebSocketMessage;
-                    SendWebSocketMessage(request);
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogError(ex.Message);
-                }
-            }
-
-            public void GetUserByUsername(string username, Action<User> onGetUserDataReceived)
-            {
-                GetUserByUsername getUserByUsernameRequest = new GetUserByUsername
+    }
+    private Item CreateItemFromData(Protobuf.Messages.Item itemData)
+    {
+        return new Item
         {
+            id = itemData.Id,
+            level = (int)itemData.Level,
+            userId = itemData.UserId,
+            unitId = itemData.UnitId,
+            template = GlobalUserData.Instance.AvailableItemTemplates.Find(itemtemplate => itemtemplate.name.ToLower() == itemData.Template.Name.ToLower())
+        };
+    }
+
+    private AfkRewardRate CreateAfkRewardRateFromData(Protobuf.Messages.AfkRewardRate afkRewardRateData)
+    {
+        return new AfkRewardRate
+        {
+            kalineTreeLevelId = afkRewardRateData.KalineTreeLevelId,
+            currency = Enum.Parse<Currency>(afkRewardRateData.Currency.Name.Replace(" ", "")),
+            rate = afkRewardRateData.Rate
+        };
+    }
+
+    private Unit CreateUnitFromData(Protobuf.Messages.Unit unitData, List<Character> availableCharacters)
+    {
+        if (!availableCharacters.Any(character => character.name.ToLower() == unitData.Character.Name.ToLower()))
+        {
+            Debug.Log($"Character not found in available characters: {unitData.Character.Name}");
+            return null;
+        }
+
+        return new Unit
+        {
+            id = unitData.Id,
+            // tier = (int)unitData.Tier,
+            character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
+            rank = (Rank)unitData.Rank,
+            level = (int)unitData.Level,
+            slot = (int?)unitData.Slot,
+            selected = unitData.Selected
+        };
+    }
+
+    private List<Unit> CreateUnitsFromData(IEnumerable<Protobuf.Messages.Unit> unitsData, List<Character> availableCharacters)
+    {
+        List<Unit> createdUnits = new List<Unit>();
+
+        foreach (var unitData in unitsData)
+        {
+            Unit unit = CreateUnitFromData(unitData, availableCharacters);
+
+            if (unit != null)
+            {
+                createdUnits.Add(unit);
+            }
+        }
+
+        return createdUnits;
+    }
+
+    private List<Campaign> ParseCampaignsFromResponse(Protobuf.Messages.Campaigns campaignsData, string superCampaignName, List<Character> availableCharacters)
+    {
+        List<(string superCampaignName, string campaignId, string levelId)> userCampaignsProgress = GlobalUserData.Instance.User.campaignsProgresses;
+        List<Campaign> campaigns = new List<Campaign>();
+        LevelProgress.Status campaignStatus = LevelProgress.Status.Completed;
+
+        // Filter campaigns by supercampaign name
+        var superCampaignCampaigns = campaignsData.Campaigns_.Where(campaign => campaign.SuperCampaignName == superCampaignName).ToList();
+
+        foreach (Protobuf.Messages.Campaign campaignData in superCampaignCampaigns)
+        {
+            LevelProgress.Status levelStatus = LevelProgress.Status.Completed;
+            List<LevelData> levels = new List<LevelData>();
+
+            foreach (Protobuf.Messages.Level level in campaignData.Levels.OrderBy(level => level.LevelNumber))
+            {
+                List<Unit> levelUnits = CreateUnitsFromData(level.Units, availableCharacters);
+
+                levelStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id && cp.levelId == level.Id) ? LevelProgress.Status.Unlocked : levelStatus;
+
+                levels.Add(new LevelData
+                {
+                    id = level.Id,
+                    levelNumber = (int)level.LevelNumber,
+                    campaignId = level.CampaignId,
+                    units = levelUnits,
+                    rewards = GetLevelCurrencyRewards(level),
+                    status = levelStatus
+                });
+
+
+                if (levelStatus == LevelProgress.Status.Unlocked)
+                {
+                    levelStatus = LevelProgress.Status.Locked;
+                }
+            }
+
+            campaignStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id) ? LevelProgress.Status.Unlocked : campaignStatus;
+
+            campaigns.Add(new Campaign
+            {
+                campaignId = campaignData.Id,
+                campaignNumber = (int)campaignData.CampaignNumber,
+                status = campaignStatus,
+                levels = levels
+            });
+
+            if (campaignStatus == LevelProgress.Status.Unlocked)
+            {
+                campaignStatus = LevelProgress.Status.Locked;
+            }
+        }
+
+        return campaigns;
+    }
+
+    // Better name for this method?
+    // This should be refactored, assigning player prefs should not be handled here
+    public void GetUserAndContinue()
+    {
+        string userId = PlayerPrefs.GetString($"userId_{ServerSelect.Name}");
+        if (String.IsNullOrEmpty(userId))
+        {
+            string userName = $"testUser-{Guid.NewGuid()}";
+            Debug.Log($"No user in player prefs, creating user with username: \"{userName}\"");
+            CreateUser(userName, (user) =>
+            {
+                GetCampaignProgresses(user.id, (progresses) =>
+                {
+                    user.campaignsProgresses = progresses;
+                });
+                PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
+                GlobalUserData.Instance.User = user;
+                Debug.Log("User created correctly");
+            });
+        }
+        else
+        {
+            Debug.Log($"Found userid: \"{userId}\" in playerprefs, getting the user");
+            GetUser(userId, (user) =>
+            {
+                GetCampaignProgresses(user.id, (progresses) =>
+                {
+                    user.campaignsProgresses = progresses;
+                });
+                PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
+                GlobalUserData.Instance.User = user;
+            });
+        }
+    }
+
+    public void GetUser(string userId, Action<User> onGetUserDataReceived)
+    {
+        try
+        {
+            GetUser getUserRequest = new GetUser
+            {
+                UserId = userId
+            };
+            WebSocketRequest request = new WebSocketRequest
+            {
+                GetUser = getUserRequest
+            };
+            currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
+            ws.OnMessage += currentMessageHandler;
+            ws.OnMessage -= OnWebSocketMessage;
+            SendWebSocketMessage(request);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError(ex.Message);
+        }
+    }
+
+    public void GetUserByUsername(string username, Action<User> onGetUserDataReceived)
+    {
         GetUserByUsername getUserByUsernameRequest = new GetUserByUsername
         {
             Username = username
         };
-        WebSocketRequest request = new WebSocketRequest
-        {
         WebSocketRequest request = new WebSocketRequest
         {
             GetUserByUsername = getUserByUsernameRequest
@@ -523,73 +363,50 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitGetUserResponse(byte[] data, Action<User> onGetUserDataReceived)
-                {
-                    try
-                    {
-                        ws.OnMessage -= currentMessageHandler;
-                        ws.OnMessage += OnWebSocketMessage;
-                        ws.OnMessage -= currentMessageHandler;
-                        ws.OnMessage += OnWebSocketMessage;
-                        WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                        if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
-                        {
-                            User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                            onGetUserDataReceived?.Invoke(user);
-                        }
-                        else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                        {
-                            switch (webSocketResponse.Error.Reason)
-                            {
-            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
-                            {
-                                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                                onGetUserDataReceived?.Invoke(user);
-                            }
-                            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                            {
-                                switch (webSocketResponse.Error.Reason)
-                                {
-                                    case "not_found":
-                                        string userName = $"testUser-{Guid.NewGuid()}";
-                                        string userName = $"testUser-{Guid.NewGuid()}";
-                                        Debug.Log($"User not found, trying to create new user with username: \"{userName}\"");
-                                        CreateUser(userName, (user) =>
-                                        {
-                                            CreateUser(userName, (user) =>
-                            {
-                                            onGetUserDataReceived?.Invoke(user);
-                                        });
-                                            break;
-                
-                                    case "username_taken":
-                                                Debug.LogError("Tried to create user, username was taken");
-                                                break;
-                                            default:
-                                                Debug.LogError(webSocketResponse.Error.Reason);
-                                                break;
-                                            }
-                                        }
-                        }
-        catch (Exception e)
-                    {
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogError("InvalidProtocolBufferException: " + e);
-                    }
-                }
-
-                public void CreateUser(string username, Action<User> onGetUserDataReceived)
-            public void CreateUser(string username, Action<User> onGetUserDataReceived)
-                {
-                    CreateUser createUserRequest = new CreateUser
+    {
+        try
         {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
+            {
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                onGetUserDataReceived?.Invoke(user);
+            }
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
+                switch (webSocketResponse.Error.Reason)
+                {
+                    case "not_found":
+                        string userName = $"testUser-{Guid.NewGuid()}";
+                        Debug.Log($"User not found, trying to create new user with username: \"{userName}\"");
+                        CreateUser(userName, (user) =>
+                        {
+                            onGetUserDataReceived?.Invoke(user);
+                        });
+                        break;
+                    case "username_taken":
+                        Debug.LogError("Tried to create user, username was taken");
+                        break;
+                    default:
+                        Debug.LogError(webSocketResponse.Error.Reason);
+                        break;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("InvalidProtocolBufferException: " + e);
+        }
+    }
+
+    public void CreateUser(string username, Action<User> onGetUserDataReceived)
+    {
         CreateUser createUserRequest = new CreateUser
         {
             Username = username
         };
-        WebSocketRequest request = new WebSocketRequest
-        {
         WebSocketRequest request = new WebSocketRequest
         {
             CreateUser = createUserRequest
@@ -601,16 +418,11 @@ public class SocketConnection : MonoBehaviour
     }
 
     public void GetCampaignProgresses(string userId, Action<List<(string, string, string)>> onCampaignProgressReceived)
-    public void GetCampaignProgresses(string userId, Action<List<(string, string, string)>> onCampaignProgressReceived)
-                    {
-                        GetUserSuperCampaignProgresses getCampaignsProgressRequest = new GetUserSuperCampaignProgresses
-        {
+    {
         GetUserSuperCampaignProgresses getCampaignsProgressRequest = new GetUserSuperCampaignProgresses
         {
             UserId = userId
         };
-        WebSocketRequest request = new WebSocketRequest
-        {
         WebSocketRequest request = new WebSocketRequest
         {
             GetUserSuperCampaignProgresses = getCampaignsProgressRequest
@@ -622,33 +434,28 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitCampaignsProgressResponse(byte[] data, Action<List<(string, string, string)>> onCampaignProgressReceived)
-    private void AwaitCampaignsProgressResponse(byte[] data, Action<List<(string, string, string)>> onCampaignProgressReceived)
-                        {
-                            try
-                            {
-                                WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.SuperCampaignProgresses)
-                                {
-                                    List<(string, string, string)> campaignProgresses = webSocketResponse.SuperCampaignProgresses.SuperCampaignProgresses_.Select(cp => (cp.SuperCampaignName, cp.CampaignId, cp.LevelId)).ToList();
-                                    onCampaignProgressReceived?.Invoke(campaignProgresses);
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                Debug.LogError(e.Message);
-                            }
-                        }
-
-                        public void GetCampaigns(string userId, string superCampaignName, Action<List<Campaign>> onCampaignDataReceived)
-                        {
-                            GetCampaigns getCampaignsRequest = new GetCampaigns
+    {
+        try
         {
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.SuperCampaignProgresses)
+            {
+                List<(string, string, string)> campaignProgresses = webSocketResponse.SuperCampaignProgresses.SuperCampaignProgresses_.Select(cp => (cp.SuperCampaignName, cp.CampaignId, cp.LevelId)).ToList();
+                onCampaignProgressReceived?.Invoke(campaignProgresses);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.Message);
+        }
+    }
+
+    public void GetCampaigns(string userId, string superCampaignName, Action<List<Campaign>> onCampaignDataReceived)
+    {
         GetCampaigns getCampaignsRequest = new GetCampaigns
         {
             UserId = userId
         };
-        WebSocketRequest request = new WebSocketRequest
-        {
         WebSocketRequest request = new WebSocketRequest
         {
             GetCampaigns = getCampaignsRequest
@@ -660,33 +467,27 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitGetCampaignsResponse(byte[] data, Action<List<Campaign>> onCampaignDataReceived, string superCampaignName)
-                            {
-                                try
-                                {
-                                    ws.OnMessage -= currentMessageHandler;
-                                    ws.OnMessage += OnWebSocketMessage;
-                                    ws.OnMessage -= currentMessageHandler;
-                                    ws.OnMessage += OnWebSocketMessage;
-                                    WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                    if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Campaigns)
-                                    {
-                                        if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Campaigns)
-                                        {
-                                            List<Character> availableCharacters = GlobalUserData.Instance.AvailableCharacters;
-                                            List<Campaign> campaigns = ParseCampaignsFromResponse(webSocketResponse.Campaigns, superCampaignName, availableCharacters);
-                                            onCampaignDataReceived?.Invoke(campaigns);
-                                        }
-                                    }
-        catch (Exception e)
-                                {
-                                    Debug.LogError(e.Message);
-                                }
-                            }
-
-                            public void SelectUnit(string unitId, string userId, int slot)
-                            {
-                                SelectUnit selectUnitRequest = new SelectUnit
+    {
+        try
         {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Campaigns)
+            {
+                List<Character> availableCharacters = GlobalUserData.Instance.AvailableCharacters;
+                List<Campaign> campaigns = ParseCampaignsFromResponse(webSocketResponse.Campaigns, superCampaignName, availableCharacters);
+                onCampaignDataReceived?.Invoke(campaigns);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.Message);
+        }
+    }
+
+    public void SelectUnit(string unitId, string userId, int slot)
+    {
         SelectUnit selectUnitRequest = new SelectUnit
         {
             UserId = userId,
@@ -695,24 +496,18 @@ public class SocketConnection : MonoBehaviour
         };
         WebSocketRequest request = new WebSocketRequest
         {
-        WebSocketRequest request = new WebSocketRequest
-        {
             SelectUnit = selectUnitRequest
         };
         SendWebSocketMessage(request);
     }
 
     public void UnselectUnit(string unitId, string userId)
-                                {
-                                    UnselectUnit unselectUnitRequest = new UnselectUnit
-        {
+    {
         UnselectUnit unselectUnitRequest = new UnselectUnit
         {
             UserId = userId,
             UnitId = unitId
         };
-        WebSocketRequest request = new WebSocketRequest
-        {
         WebSocketRequest request = new WebSocketRequest
         {
             UnselectUnit = unselectUnitRequest
@@ -721,73 +516,49 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitBattleResponse(byte[] data, Action<BattleResult> onBattleResultReceived)
-    private void AwaitBattleResponse(byte[] data, Action<BattleResult> onBattleResultReceived)
-                                    {
-                                        try
-                                        {
-                                            ws.OnMessage -= currentMessageHandler;
-                                            ws.OnMessage -= currentMessageHandler;
-                                            ws.OnMessage += OnWebSocketMessage;
-                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.BattleResult)
-                                            {
-                                                if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.BattleResult)
-                                                {
-                                                    onBattleResultReceived?.Invoke(webSocketResponse.BattleResult);
-                                                }
-                                            }
-        catch (Exception e)
-                                        {
-                                            Debug.LogError(e.Message);
-                                        }
-                                    }
-
-                                    public IEnumerator Battle(string userId, string levelId, Action<BattleResult> onBattleResultReceived)
-                                    {
-                                        FightLevel fightLevelRequest = new FightLevel
-                                        {
-                                            UserId = userId,
-                                            LevelId = levelId
-                                        };
-                                        WebSocketRequest request = new WebSocketRequest
-                                        {
-                                            FightLevel = fightLevelRequest
-                                        };
-                                        currentMessageHandler = (data) => AwaitBattleResponse(data, onBattleResultReceived);
-                                        public IEnumerator Battle(string userId, string levelId, Action<BattleResult> onBattleResultReceived)
-                                        {
-                                            FightLevel fightLevelRequest = new FightLevel
-                                            {
-                                                UserId = userId,
-                                                LevelId = levelId
-                                            };
-                                            WebSocketRequest request = new WebSocketRequest
-                                            {
-                                                FightLevel = fightLevelRequest
-                                            };
-                                            currentMessageHandler = (data) => AwaitBattleResponse(data, onBattleResultReceived);
-                                            ws.OnMessage += currentMessageHandler;
-                                            ws.OnMessage -= OnWebSocketMessage;
-                                            SendWebSocketMessage(request);
-                                            yield return null;
-                                        }
-                                        yield return null;
-                                    }
-
-                                    public void EquipItem(string userId, string itemId, string unitId, Action<Item> onItemDataReceived)
-                                    {
-                                        EquipItem equipItemRequest = new EquipItem
-                                        {
-    public void EquipItem(string userId, string itemId, string unitId, Action<Item> onItemDataReceived)
-                                        {
-                                            EquipItem equipItemRequest = new EquipItem
-                                            {
-                                                UserId = userId,
-                                                ItemId = itemId,
-                                                UnitId = unitId
-                                            };
-                                            WebSocketRequest request = new WebSocketRequest
+    {
+        try
         {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.BattleResult)
+            {
+                onBattleResultReceived?.Invoke(webSocketResponse.BattleResult);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.Message);
+        }
+    }
+
+    public IEnumerator Battle(string userId, string levelId, Action<BattleResult> onBattleResultReceived)
+    {
+        FightLevel fightLevelRequest = new FightLevel
+        {
+            UserId = userId,
+            LevelId = levelId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            FightLevel = fightLevelRequest
+        };
+        currentMessageHandler = (data) => AwaitBattleResponse(data, onBattleResultReceived);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+        yield return null;
+    }
+
+    public void EquipItem(string userId, string itemId, string unitId, Action<Item> onItemDataReceived)
+    {
+        EquipItem equipItemRequest = new EquipItem
+        {
+            UserId = userId,
+            ItemId = itemId,
+            UnitId = unitId
+        };
         WebSocketRequest request = new WebSocketRequest
         {
             EquipItem = equipItemRequest
@@ -799,18 +570,12 @@ public class SocketConnection : MonoBehaviour
     }
 
     public void UnequipItem(string userId, string itemId, Action<Item> onItemDataReceived)
-                                            {
-                                                UnequipItem unequipItemRequest = new UnequipItem
-                                                {
-    public void UnequipItem(string userId, string itemId, Action<Item> onItemDataReceived)
-                                                {
-                                                    UnequipItem unequipItemRequest = new UnequipItem
-                                                    {
-                                                        UserId = userId,
-                                                        ItemId = itemId
-                                                    };
-                                                    WebSocketRequest request = new WebSocketRequest
+    {
+        UnequipItem unequipItemRequest = new UnequipItem
         {
+            UserId = userId,
+            ItemId = itemId
+        };
         WebSocketRequest request = new WebSocketRequest
         {
             UnequipItem = unequipItemRequest
@@ -822,18 +587,12 @@ public class SocketConnection : MonoBehaviour
     }
 
     public void LevelUpItem(string userId, string itemId, Action<Item> onItemDataReceived, Action<string> onError)
-                                                    {
-                                                        LevelUpItem levelUpItemRequest = new LevelUpItem
-                                                        {
-    public void LevelUpItem(string userId, string itemId, Action<Item> onItemDataReceived, Action<string> onError)
-                                                        {
-                                                            LevelUpItem levelUpItemRequest = new LevelUpItem
-                                                            {
-                                                                UserId = userId,
-                                                                ItemId = itemId
-                                                            };
-                                                            WebSocketRequest request = new WebSocketRequest
+    {
+        LevelUpItem levelUpItemRequest = new LevelUpItem
         {
+            UserId = userId,
+            ItemId = itemId
+        };
         WebSocketRequest request = new WebSocketRequest
         {
             LevelUpItem = levelUpItemRequest
@@ -845,46 +604,35 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitItemResponse(byte[] data, Action<Item> onItemDataReceived, Action<string> onError = null)
-                                                            {
-                                                                try
-                                                                {
-                                                                    ws.OnMessage -= currentMessageHandler;
-                                                                    ws.OnMessage -= currentMessageHandler;
-                                                                    ws.OnMessage += OnWebSocketMessage;
-                                                                    WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                    if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Item)
-                                                                    {
-                                                                        if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Item)
-                                                                        {
-                                                                            Item item = CreateItemFromData(webSocketResponse.Item);
-                                                                            onItemDataReceived?.Invoke(item);
-                                                                        }
-                                                                        else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                        {
-            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                            {
-                                                                                onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                            }
-                                                                        }
-        catch (Exception e)
-                                                                {
-                                                                    Debug.LogError(e.Message);
-                                                                }
-                                                            }
-
-                                                            public void LevelUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError)
-                                                            {
-                                                                LevelUpUnit levelUpUnitRequest = new LevelUpUnit
-                                                                {
-    public void LevelUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError)
-                                                                {
-                                                                    LevelUpUnit levelUpUnitRequest = new LevelUpUnit
-                                                                    {
-                                                                        UserId = userId,
-                                                                        UnitId = unitId
-                                                                    };
-                                                                    WebSocketRequest request = new WebSocketRequest
+    {
+        try
         {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Item)
+            {
+                Item item = CreateItemFromData(webSocketResponse.Item);
+                onItemDataReceived?.Invoke(item);
+            }
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.Message);
+        }
+    }
+
+    public void LevelUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError)
+    {
+        LevelUpUnit levelUpUnitRequest = new LevelUpUnit
+        {
+            UserId = userId,
+            UnitId = unitId
+        };
         WebSocketRequest request = new WebSocketRequest
         {
             LevelUpUnit = levelUpUnitRequest
@@ -896,129 +644,86 @@ public class SocketConnection : MonoBehaviour
     }
 
     private void AwaitUnitAndCurrenciesReponse(byte[] data, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError = null)
-                                                                    {
-                                                                        try
-                                                                        {
-                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UnitAndCurrencies)
-                                                                            {
-                                                                                if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UnitAndCurrencies)
-                                                                                {
-                                                                                    onUnitAndCurrenciesDataReceived?.Invoke(webSocketResponse.UnitAndCurrencies);
-                                                                                }
-                                                                                else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                {
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UnitAndCurrencies)
+            {
+                onUnitAndCurrenciesDataReceived?.Invoke(webSocketResponse.UnitAndCurrencies);
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                    {
-                                                                                        onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                    }
-                                                                                }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
         catch (Exception e)
-                                                                        {
-                                                                            Debug.LogError(e.Message);
-                                                                        }
-                                                                    }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
 
-                                                                    public void GetBoxes(Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
-                                                                    {
-                                                                        GetBoxes getBoxesRequest = new GetBoxes();
-                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                        {
     public void GetBoxes(Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
-                                                                        {
-                                                                            GetBoxes getBoxesRequest = new GetBoxes();
-                                                                            WebSocketRequest request = new WebSocketRequest
-                                                                            {
-                                                                                GetBoxes = getBoxesRequest
-                                                                            };
-                                                                            currentMessageHandler = (data) => AwaitBoxesReponse(data, onBoxesDataReceived, onError);
-                                                                            ws.OnMessage += currentMessageHandler;
-                                                                            ws.OnMessage -= OnWebSocketMessage;
-                                                                            SendWebSocketMessage(request);
-                                                                        }
-                                                                    }
+    {
+        GetBoxes getBoxesRequest = new GetBoxes();
+        WebSocketRequest request = new WebSocketRequest
+        {
+            GetBoxes = getBoxesRequest
+        };
+        currentMessageHandler = (data) => AwaitBoxesReponse(data, onBoxesDataReceived, onError);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
 
-                                                                    private void AwaitBoxesReponse(byte[] data, Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
-                                                                    {
-                                                                        try
     private void AwaitBoxesReponse(byte[] data, Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
-                                                                        {
-                                                                            try
-                                                                            {
-                                                                                ws.OnMessage -= currentMessageHandler;
-                                                                                ws.OnMessage -= currentMessageHandler;
-                                                                                ws.OnMessage += OnWebSocketMessage;
-                                                                                WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Boxes)
-                                                                                {
-                                                                                    List<Box> boxes = ParseBoxesFromResponse(webSocketResponse.Boxes);
-                                                                                    if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Boxes)
-                                                                                    {
-                                                                                        List<Box> boxes = ParseBoxesFromResponse(webSocketResponse.Boxes);
-                                                                                        onBoxesDataReceived?.Invoke(boxes);
-                                                                                    }
-                                                                                    else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                    {
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Boxes)
+            {
+                List<Box> boxes = ParseBoxesFromResponse(webSocketResponse.Boxes);
+                onBoxesDataReceived?.Invoke(boxes);
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                        {
-                                                                                            onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                        }
-                                                                                    }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
         catch (Exception e)
-                                                                            {
-                                                                                Debug.LogError(e.Message);
-                                                                            }
-                                                                        }
-                                                                        }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
 
     private List<Box> ParseBoxesFromResponse(Boxes boxesMessage)
-                                                                        {
-                                                                            return boxesMessage.Boxes_.Select(box =>
-                                                                            {
-                                                                                return new Box
-                                                                                {
-                                                                                    id = box.Id,
-                                                                                    name = box.Name,
-                                                                                    description = box.Description,
-                                                                                    factions = box.Factions.ToList(),
-                                                                                    rankWeights = box.RankWeights.ToDictionary(rankWeight => rankWeight.Rank, rankWeight => rankWeight.Weight),
-                                                                                    costs = box.Cost.ToDictionary(cost => Enum.Parse<Currency>(cost.Currency.Name.Replace(" ", "")), cost => cost.Amount)
-                                                                                };
-                                                                            }).ToList();
-                                                                        }
-                                                                        private List<Box> ParseBoxesFromResponse(Boxes boxesMessage)
-                                                                        {
-                                                                            return boxesMessage.Boxes_.Select(box =>
-                                                                            {
-                                                                                return new Box
-                                                                                {
-                                                                                    id = box.Id,
-                                                                                    name = box.Name,
-                                                                                    description = box.Description,
-                                                                                    factions = box.Factions.ToList(),
-                                                                                    rankWeights = box.RankWeights.ToDictionary(rankWeight => rankWeight.Rank, rankWeight => rankWeight.Weight),
-                                                                                    costs = box.Cost.ToDictionary(cost => Enum.Parse<Currency>(cost.Currency.Name.Replace(" ", "")), cost => cost.Amount)
-                                                                                };
-                                                                            }).ToList();
-                                                                        }
-
-                                                                        public void Summon(string userId, string boxId, Action<User, Unit> onSuccess, Action<string> onError = null)
-                                                                        {
-                                                                            Summon summonRequest = new Summon
-                                                                            {
-    public void Summon(string userId, string boxId, Action<User, Unit> onSuccess, Action<string> onError = null)
-                                                                            {
-                                                                                Summon summonRequest = new Summon
-                                                                                {
-                                                                                    UserId = userId,
-                                                                                    BoxId = boxId
-                                                                                };
-                                                                                WebSocketRequest request = new WebSocketRequest
+    {
+        return boxesMessage.Boxes_.Select(box =>
         {
+            return new Box
+            {
+                id = box.Id,
+                name = box.Name,
+                description = box.Description,
+                factions = box.Factions.ToList(),
+                rankWeights = box.RankWeights.ToDictionary(rankWeight => rankWeight.Rank, rankWeight => rankWeight.Weight),
+                costs = box.Cost.ToDictionary(cost => Enum.Parse<Currency>(cost.Currency.Name.Replace(" ", "")), cost => cost.Amount)
+            };
+        }).ToList();
+    }
+
+    public void Summon(string userId, string boxId, Action<User, Unit> onSuccess, Action<string> onError = null)
+    {
+        Summon summonRequest = new Summon
+        {
+            UserId = userId,
+            BoxId = boxId
+        };
         WebSocketRequest request = new WebSocketRequest
         {
             Summon = summonRequest
@@ -1028,248 +733,204 @@ public class SocketConnection : MonoBehaviour
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
     }
+
+    private void AwaitSummonResponse(byte[] data, Action<User, Unit> onSuccess, Action<string> onError)
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UserAndUnit)
+            {
+                User user = CreateUserFromData(webSocketResponse.UserAndUnit.User, GlobalUserData.Instance.AvailableCharacters);
+                Unit unit = CreateUnitFromData(webSocketResponse.UserAndUnit.Unit, GlobalUserData.Instance.AvailableCharacters);
+                onSuccess?.Invoke(user, unit);
+            }
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.Message);
+        }
     }
 
-                                                                            private void AwaitSummonResponse(byte[] data, Action<User, Unit> onSuccess, Action<string> onError)
-                                                                            {
-                                                                                try
-    private void AwaitSummonResponse(byte[] data, Action<User, Unit> onSuccess, Action<string> onError)
-                                                                                {
-                                                                                    try
-                                                                                    {
-                                                                                        ws.OnMessage -= currentMessageHandler;
-                                                                                        ws.OnMessage -= currentMessageHandler;
-                                                                                        ws.OnMessage += OnWebSocketMessage;
-                                                                                        WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                        if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UserAndUnit)
-                                                                                        {
-                                                                                            User user = CreateUserFromData(webSocketResponse.UserAndUnit.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                            Unit unit = CreateUnitFromData(webSocketResponse.UserAndUnit.Unit, GlobalUserData.Instance.AvailableCharacters);
-                                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UserAndUnit)
-                                                                                            {
-                                                                                                User user = CreateUserFromData(webSocketResponse.UserAndUnit.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                Unit unit = CreateUnitFromData(webSocketResponse.UserAndUnit.Unit, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                onSuccess?.Invoke(user, unit);
-                                                                                            }
-                                                                                            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                            {
-            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                {
-                                                                                                    onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                                }
-                                                                                            }
-        catch (Exception e)
-                                                                                    {
-                                                                                        Debug.LogError(e.Message);
-                                                                                    }
-                                                                                }
-                                                                                }
-
     public void FuseUnits(string userId, string unitId, string[] consumedUnitsIds, Action<Unit> onSuccess, Action<string> onError = null)
-                                                                                {
-                                                                                    FuseUnit fuseRequest = new FuseUnit
-                                                                                    {
-    public void FuseUnits(string userId, string unitId, string[] consumedUnitsIds, Action<Unit> onSuccess, Action<string> onError = null)
-                                                                                    {
-                                                                                        FuseUnit fuseRequest = new FuseUnit
-                                                                                        {
-                                                                                            UserId = userId,
-                                                                                            UnitId = unitId,
-                                                                                        };
-                                                                                        // Why on earth repeated fields don't have a setter but you can still add values to them?
-                                                                                        foreach (string consumedUnitId in consumedUnitsIds)
-                                                                                        {
-                                                                                            fuseRequest.ConsumedUnitsIds.Add(consumedUnitId);
-                                                                                        }
-                                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                                        {
+    {
+        FuseUnit fuseRequest = new FuseUnit
+        {
+            UserId = userId,
+            UnitId = unitId,
+        };
         // Why on earth repeated fields don't have a setter but you can still add values to them?
         foreach (string consumedUnitId in consumedUnitsIds)
-                                                                                        {
-                                                                                            fuseRequest.ConsumedUnitsIds.Add(consumedUnitId);
-                                                                                        }
-                                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                                        {
-                                                                                            FuseUnit = fuseRequest
-                                                                                        };
-                                                                                        currentMessageHandler = (data) => AwaitFuseUnitsResponse(data, onSuccess, onError);
-                                                                                        ws.OnMessage += currentMessageHandler;
-                                                                                        ws.OnMessage -= OnWebSocketMessage;
-                                                                                        SendWebSocketMessage(request);
-                                                                                    }
-                                                                                }
+        {
+            fuseRequest.ConsumedUnitsIds.Add(consumedUnitId);
+        }
+        WebSocketRequest request = new WebSocketRequest
+        {
+            FuseUnit = fuseRequest
+        };
+        currentMessageHandler = (data) => AwaitFuseUnitsResponse(data, onSuccess, onError);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
 
-                                                                                private void AwaitFuseUnitsResponse(byte[] data, Action<Unit> onSuccess, Action<string> onError)
-                                                                                {
-                                                                                    try
     private void AwaitFuseUnitsResponse(byte[] data, Action<Unit> onSuccess, Action<string> onError)
-                                                                                    {
-                                                                                        try
-                                                                                        {
-                                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Unit)
-                                                                                            {
-                                                                                                Unit unit = CreateUnitFromData(webSocketResponse.Unit, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Unit)
-                                                                                                {
-                                                                                                    Unit unit = CreateUnitFromData(webSocketResponse.Unit, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                    onSuccess?.Invoke(unit);
-                                                                                                }
-                                                                                                else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                {
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Unit)
+            {
+                Unit unit = CreateUnitFromData(webSocketResponse.Unit, GlobalUserData.Instance.AvailableCharacters);
+                onSuccess?.Invoke(unit);
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                    {
-                                                                                                        onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                                    }
-                                                                                                }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
         catch (Exception e)
-                                                                                        {
-                                                                                            Debug.LogError(e.Message);
-                                                                                        }
-                                                                                    }
-                                                                                    }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
 
     private Dictionary<Currency, int> GetLevelCurrencyRewards(Level level)
-                                                                                    {
-                                                                                        Dictionary<Currency, int> rewards = level.CurrencyRewards.ToDictionary(currencyReward => Enum.Parse<Currency>(currencyReward.Currency.Name.Replace(" ", "")), currencyReward => (int)currencyReward.Amount);
-                                                                                        rewards.Add(Currency.Experience, (int)level.ExperienceReward);
-                                                                                        return rewards;
-                                                                                    }
+    {
+        Dictionary<Currency, int> rewards = level.CurrencyRewards.ToDictionary(currencyReward => Enum.Parse<Currency>(currencyReward.Currency.Name.Replace(" ", "")), currencyReward => (int)currencyReward.Amount);
+        rewards.Add(Currency.Experience, (int)level.ExperienceReward);
+        return rewards;
+    }
 
-                                                                                    public void GetAfkRewards(string userId, Action<List<AfkReward>> onAfkRewardsReceived)
-                                                                                    {
-                                                                                        GetAfkRewards getAfkRewardsRequest = new GetAfkRewards
-                                                                                        {
-                                                                                            UserId = userId
-                                                                                        };
-                                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                                        {
-                                                                                            GetAfkRewards = getAfkRewardsRequest
-                                                                                        };
-                                                                                        currentMessageHandler = (data) => AwaitGetAfkRewardsResponse(data, onAfkRewardsReceived);
-                                                                                        ws.OnMessage += currentMessageHandler;
-                                                                                        ws.OnMessage -= OnWebSocketMessage;
-                                                                                        SendWebSocketMessage(request);
-                                                                                    }
+    public void GetAfkRewards(string userId, Action<List<AfkReward>> onAfkRewardsReceived)
+    {
+        GetAfkRewards getAfkRewardsRequest = new GetAfkRewards
+        {
+            UserId = userId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            GetAfkRewards = getAfkRewardsRequest
+        };
+        currentMessageHandler = (data) => AwaitGetAfkRewardsResponse(data, onAfkRewardsReceived);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
 
-                                                                                    private void AwaitGetAfkRewardsResponse(byte[] data, Action<List<AfkReward>> onAfkRewardsReceived, Action<string> onError = null)
-                                                                                    {
-                                                                                        try
-                                                                                        {
-                                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.AfkRewards)
-                                                                                            {
-                                                                                                List<AfkReward> afkRewards = webSocketResponse.AfkRewards.AfkRewards_.Select(afkReward => new AfkReward
-                                                                                                {
-                                                                                                    currency = Enum.Parse<Currency>(afkReward.Currency.Name.Replace(" ", "")),
-                                                                                                    amount = (int)afkReward.Amount
-                                                                                                }).ToList();
-                                                                                                onAfkRewardsReceived?.Invoke(afkRewards);
-                                                                                            }
-                                                                                            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                            {
+    private void AwaitGetAfkRewardsResponse(byte[] data, Action<List<AfkReward>> onAfkRewardsReceived, Action<string> onError = null)
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.AfkRewards)
+            {
+                List<AfkReward> afkRewards = webSocketResponse.AfkRewards.AfkRewards_.Select(afkReward => new AfkReward
+                {
+                    currency = Enum.Parse<Currency>(afkReward.Currency.Name.Replace(" ", "")),
+                    amount = (int)afkReward.Amount
+                }).ToList();
+                onAfkRewardsReceived?.Invoke(afkRewards);
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                {
-                                                                                                    onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                                }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
 
-                                                                                            }
+        }
         catch (Exception e)
-                                                                                        {
-                                                                                            Debug.LogError(e.Message);
-                                                                                        }
-                                                                                    }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
 
-                                                                                    public void ClaimAfkRewards(string userId, Action<User> onAfkRewardsReceived)
-                                                                                    {
-                                                                                        ClaimAfkRewards claimAfkRewardsRequest = new ClaimAfkRewards
-                                                                                        {
-                                                                                            UserId = userId
-                                                                                        };
-                                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                                        {
-                                                                                            ClaimAfkRewards = claimAfkRewardsRequest
-                                                                                        };
-                                                                                        currentMessageHandler = (data) => AwaitClaimAfkRewardsResponse(data, onAfkRewardsReceived);
-                                                                                        ws.OnMessage += currentMessageHandler;
-                                                                                        ws.OnMessage -= OnWebSocketMessage;
-                                                                                        SendWebSocketMessage(request);
-                                                                                    }
+    public void ClaimAfkRewards(string userId, Action<User> onAfkRewardsReceived)
+    {
+        ClaimAfkRewards claimAfkRewardsRequest = new ClaimAfkRewards
+        {
+            UserId = userId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            ClaimAfkRewards = claimAfkRewardsRequest
+        };
+        currentMessageHandler = (data) => AwaitClaimAfkRewardsResponse(data, onAfkRewardsReceived);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
 
-                                                                                    private void AwaitClaimAfkRewardsResponse(byte[] data, Action<User> onAfkRewardsReceived, Action<string> onError = null)
-                                                                                    {
-                                                                                        try
-                                                                                        {
-                                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
-                                                                                            {
-                                                                                                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                onAfkRewardsReceived?.Invoke(user);
-                                                                                                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                onAfkRewardsReceived?.Invoke(user);
-                                                                                            }
-                                                                                            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                            {
+    private void AwaitClaimAfkRewardsResponse(byte[] data, Action<User> onAfkRewardsReceived, Action<string> onError = null)
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
+            {
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                onAfkRewardsReceived?.Invoke(user);
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                {
-                                                                                                    onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                                }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
 
-                                                                                            }
+        }
         catch (Exception e)
-                                                                                        {
-                                                                                            Debug.LogError(e.Message);
-                                                                                        }
-                                                                                    }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
 
-                                                                                    public void LevelUpKalineTree(string userId, Action<User> onLeveledUpUserReceived, Action<string> onError = null)
-                                                                                    {
-                                                                                        LevelUpKalineTree levelUpKalineTreeRequest = new LevelUpKalineTree
-                                                                                        {
-                                                                                            UserId = userId
-                                                                                        };
-                                                                                        WebSocketRequest request = new WebSocketRequest
-                                                                                        {
-                                                                                            LevelUpKalineTree = levelUpKalineTreeRequest
-                                                                                        };
-                                                                                        currentMessageHandler = (data) => AwaitLevelUpKalineTreeResponse(data, onLeveledUpUserReceived, onError);
-                                                                                        currentMessageHandler = (data) => AwaitLevelUpKalineTreeResponse(data, onLeveledUpUserReceived, onError);
-                                                                                        ws.OnMessage += currentMessageHandler;
-                                                                                        ws.OnMessage -= OnWebSocketMessage;
-                                                                                        SendWebSocketMessage(request);
-                                                                                    }
+    public void LevelUpKalineTree(string userId, Action<User> onLeveledUpUserReceived, Action<string> onError = null)
+    {
+        LevelUpKalineTree levelUpKalineTreeRequest = new LevelUpKalineTree
+        {
+            UserId = userId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            LevelUpKalineTree = levelUpKalineTreeRequest
+        };
+        currentMessageHandler = (data) => AwaitLevelUpKalineTreeResponse(data, onLeveledUpUserReceived, onError);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
 
-                                                                                    private void AwaitLevelUpKalineTreeResponse(byte[] data, Action<User> onLeveledUpUserReceived, Action<string> onError = null)
-                                                                                    {
-                                                                                        try
-                                                                                        {
-                                                                                            ws.OnMessage -= currentMessageHandler;
-                                                                                            ws.OnMessage += OnWebSocketMessage;
-                                                                                            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-                                                                                            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
-                                                                                            {
-                                                                                                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-                                                                                                onLeveledUpUserReceived?.Invoke(user);
-                                                                                                GlobalUserData.Instance.User.kalineTreeLevel = user.kalineTreeLevel;
-                                                                                            }
-                                                                                            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                            {
+    private void AwaitLevelUpKalineTreeResponse(byte[] data, Action<User> onLeveledUpUserReceived, Action<string> onError = null)
+    {
+        try
+        {
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
+            WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
+            {
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                onLeveledUpUserReceived?.Invoke(user);
+                GlobalUserData.Instance.User.kalineTreeLevel = user.kalineTreeLevel;
+            }
             else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-                                                                                                {
-                                                                                                    onError?.Invoke(webSocketResponse.Error.Reason);
-                                                                                                }
-                                                                                            }
+            {
+                onError?.Invoke(webSocketResponse.Error.Reason);
+            }
+        }
         catch (Exception e)
-                                                                                        {
-                                                                                            Debug.LogError(e.Message);
-                                                                                        }
-                                                                                    }
-                                                                                }
+        {
+            Debug.LogError(e.Message);
+        }
+    }
+}

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -9,7 +9,8 @@ using NativeWebSocket;
 using Protobuf.Messages;
 using UnityEngine;
 
-public class SocketConnection : MonoBehaviour {
+public class SocketConnection : MonoBehaviour
+{
     WebSocket ws;
 
     public static SocketConnection Instance;
@@ -23,19 +24,19 @@ public class SocketConnection : MonoBehaviour {
         Init();
     }
 
-	public void Init()
-	{
-		Instance = this;
-		DontDestroyOnLoad(gameObject);
+    public void Init()
+    {
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
 
-		if (!connected)
-		{
-			connected = true;
-			ConnectToSession();
-		}
-	}
+        if (!connected)
+        {
+            connected = true;
+            ConnectToSession();
+        }
+    }
 
-	void Update()
+    void Update()
     {
 #if !UNITY_WEBGL || UNITY_EDITOR
         if (ws != null)
@@ -52,7 +53,7 @@ public class SocketConnection : MonoBehaviour {
 
     private void ConnectToSession()
     {
-		string url = $"{ServerSelect.Domain}/2";
+        string url = $"{ServerSelect.Domain}/2";
         ws = new WebSocket(url);
         ws.OnMessage += OnWebSocketMessage;
         ws.OnClose += OnWebsocketClose;
@@ -88,19 +89,22 @@ public class SocketConnection : MonoBehaviour {
             message.WriteTo(stream);
             var msg = stream.ToArray();
 
-            if(ws != null) {
+            if (ws != null)
+            {
                 ws.Send(msg);
             }
         }
     }
 
-	public async Task CloseConnection() {
-		if(connected && this.ws != null) {
-			await this.ws.Close();
-			connected = false;
-		}
-	}
-    
+    public async Task CloseConnection()
+    {
+        if (connected && this.ws != null)
+        {
+            await this.ws.Close();
+            connected = false;
+        }
+    }
+
     private void OnWebSocketMessage(byte[] data)
     {
         try
@@ -125,29 +129,29 @@ public class SocketConnection : MonoBehaviour {
         }
     }
 
-	private User CreateUserFromData(Protobuf.Messages.User user, List<Character> availableCharacters)
-	{
-		List<Unit> units = CreateUnitsFromData(user.Units, availableCharacters);
-		List<Item> items = new List<Item>();
+    private User CreateUserFromData(Protobuf.Messages.User user, List<Character> availableCharacters)
+    {
+        List<Unit> units = CreateUnitsFromData(user.Units, availableCharacters);
+        List<Item> items = new List<Item>();
 
-		foreach (var userItem in user.Items)
-		{
-			items.Add(CreateItemFromData(userItem));
-		}
+        foreach (var userItem in user.Items)
+        {
+            items.Add(CreateItemFromData(userItem));
+        }
 
-		Dictionary<Currency, int> currencies = new Dictionary<Currency, int>();
+        Dictionary<Currency, int> currencies = new Dictionary<Currency, int>();
 
-		foreach (var currency in user.Currencies)
-		{
-			if (Enum.TryParse<Currency>(currency.Currency.Name.Replace(" ", ""), out Currency currencyValue))
-			{
-				currencies.Add(currencyValue, (int)currency.Amount);
-			}
-			else
-			{
-				Debug.LogError($"Currency brought from the backend not found in client: {currency.Currency.Name}");
-			}
-		}
+        foreach (var currency in user.Currencies)
+        {
+            if (Enum.TryParse<Currency>(currency.Currency.Name.Replace(" ", ""), out Currency currencyValue))
+            {
+                currencies.Add(currencyValue, (int)currency.Amount);
+            }
+            else
+            {
+                Debug.LogError($"Currency brought from the backend not found in client: {currency.Currency.Name}");
+            }
+        }
 
         KalineTreeLevel kalineTreeLevel = new KalineTreeLevel
         {
@@ -157,19 +161,20 @@ public class SocketConnection : MonoBehaviour {
             afkRewardRates = user.KalineTreeLevel.AfkRewardRates.Select(afkRewardRate => CreateAfkRewardRateFromData(afkRewardRate)).ToList()
         };
 
-		return new User
-		{
-			id = user.Id,
-			username = user.Username,
-			units = units,
-			items = items,
-			currencies = currencies,
-			level = (int)user.Level,
-			experience = (int)user.Experience,
+        return new User
+        {
+            id = user.Id,
+            username = user.Username,
+            units = units,
+            items = items,
+            currencies = currencies,
+            level = (int)user.Level,
+            experience = (int)user.Experience,
             kalineTreeLevel = kalineTreeLevel
-		};
-	}
-    private Item CreateItemFromData(Protobuf.Messages.Item itemData) {
+        };
+    }
+    private Item CreateItemFromData(Protobuf.Messages.Item itemData)
+    {
         return new Item
         {
             id = itemData.Id,
@@ -190,59 +195,62 @@ public class SocketConnection : MonoBehaviour {
         };
     }
 
-	private Unit CreateUnitFromData(Protobuf.Messages.Unit unitData, List<Character> availableCharacters)
-	{
-		if (!availableCharacters.Any(character => character.name.ToLower() == unitData.Character.Name.ToLower()))
-		{
-			Debug.Log($"Character not found in available characters: {unitData.Character.Name}");
-			return null;
-		}
+    private Unit CreateUnitFromData(Protobuf.Messages.Unit unitData, List<Character> availableCharacters)
+    {
+        if (!availableCharacters.Any(character => character.name.ToLower() == unitData.Character.Name.ToLower()))
+        {
+            Debug.Log($"Character not found in available characters: {unitData.Character.Name}");
+            return null;
+        }
 
-		return new Unit
-		{
-			id = unitData.Id,
-			// tier = (int)unitData.Tier,
-			character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
-			rank = (Rank)unitData.Rank,
-			level = (int)unitData.Level,
-			slot = (int?)unitData.Slot,
-			selected = unitData.Selected
-		};
-	}
+        return new Unit
+        {
+            id = unitData.Id,
+            // tier = (int)unitData.Tier,
+            character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
+            rank = (Rank)unitData.Rank,
+            level = (int)unitData.Level,
+            slot = (int?)unitData.Slot,
+            selected = unitData.Selected
+        };
+    }
 
     private List<Unit> CreateUnitsFromData(IEnumerable<Protobuf.Messages.Unit> unitsData, List<Character> availableCharacters)
-	{
-		List<Unit> createdUnits = new List<Unit>();
-
-		foreach (var unitData in unitsData)
-		{
-			Unit unit = CreateUnitFromData(unitData, availableCharacters);
-	
-			if(unit != null) {
-				createdUnits.Add(unit);
-			}
-		}
-
-		return createdUnits;
-	}
-
-	private List<Campaign> ParseCampaignsFromResponse(Protobuf.Messages.Campaigns campaignsData, List<Character> availableCharacters)
     {
-		List<(string superCampaignId, string campaignId, string levelId)> userCampaignsProgress = GlobalUserData.Instance.User.campaignsProgresses;
-        List<Campaign> campaigns = new List<Campaign>();
-		LevelProgress.Status campaignStatus = LevelProgress.Status.Completed;
+        List<Unit> createdUnits = new List<Unit>();
 
-		// Currently looping through all the campaigns like they all belong to the same super campaign
-		foreach(Protobuf.Messages.Campaign campaignData in campaignsData.Campaigns_)
+        foreach (var unitData in unitsData)
         {
-			LevelProgress.Status levelStatus = LevelProgress.Status.Completed;
-            List<LevelData> levels = new List<LevelData>();
-			
-			foreach(Protobuf.Messages.Level level in campaignData.Levels.OrderBy(level => level.LevelNumber))
-            {
-				List<Unit> levelUnits = CreateUnitsFromData(level.Units, availableCharacters);
+            Unit unit = CreateUnitFromData(unitData, availableCharacters);
 
-				levelStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id && cp.levelId == level.Id) ? LevelProgress.Status.Unlocked : levelStatus;
+            if (unit != null)
+            {
+                createdUnits.Add(unit);
+            }
+        }
+
+        return createdUnits;
+    }
+
+    private List<Campaign> ParseCampaignsFromResponse(Protobuf.Messages.Campaigns campaignsData, string superCampaignName, List<Character> availableCharacters)
+    {
+        List<(string superCampaignName, string campaignId, string levelId)> userCampaignsProgress = GlobalUserData.Instance.User.campaignsProgresses;
+        List<Campaign> campaigns = new List<Campaign>();
+        LevelProgress.Status campaignStatus = LevelProgress.Status.Completed;
+
+        // Filter campaigns by supercampaign name
+        var superCampaignCampaigns = campaignsData.Campaigns_.Where(campaign => campaign.SuperCampaignName == superCampaignName).ToList();
+
+        foreach (Protobuf.Messages.Campaign campaignData in superCampaignCampaigns)
+        {
+            LevelProgress.Status levelStatus = LevelProgress.Status.Completed;
+            List<LevelData> levels = new List<LevelData>();
+
+            foreach (Protobuf.Messages.Level level in campaignData.Levels.OrderBy(level => level.LevelNumber))
+            {
+                List<Unit> levelUnits = CreateUnitsFromData(level.Units, availableCharacters);
+
+                levelStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id && cp.levelId == level.Id) ? LevelProgress.Status.Unlocked : levelStatus;
 
                 levels.Add(new LevelData
                 {
@@ -250,29 +258,31 @@ public class SocketConnection : MonoBehaviour {
                     levelNumber = (int)level.LevelNumber,
                     campaignId = level.CampaignId,
                     units = levelUnits,
-					rewards = GetLevelCurrencyRewards(level),
+                    rewards = GetLevelCurrencyRewards(level),
                     status = levelStatus
                 });
 
-                
-				if(levelStatus == LevelProgress.Status.Unlocked) {
-					levelStatus = LevelProgress.Status.Locked;
-				}
+
+                if (levelStatus == LevelProgress.Status.Unlocked)
+                {
+                    levelStatus = LevelProgress.Status.Locked;
+                }
             }
 
-			campaignStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id) ? LevelProgress.Status.Unlocked : campaignStatus;
+            campaignStatus = userCampaignsProgress.Any(cp => cp.campaignId == campaignData.Id) ? LevelProgress.Status.Unlocked : campaignStatus;
 
             campaigns.Add(new Campaign
             {
-				campaignId = campaignData.Id,
-				campaignNumber = (int)campaignData.CampaignNumber,
+                campaignId = campaignData.Id,
+                campaignNumber = (int)campaignData.CampaignNumber,
                 status = campaignStatus,
                 levels = levels
             });
 
-			if(campaignStatus == LevelProgress.Status.Unlocked) {
-				campaignStatus = LevelProgress.Status.Locked;
-			}
+            if (campaignStatus == LevelProgress.Status.Unlocked)
+            {
+                campaignStatus = LevelProgress.Status.Locked;
+            }
         }
 
         return campaigns;
@@ -282,55 +292,68 @@ public class SocketConnection : MonoBehaviour {
     // This should be refactored, assigning player prefs should not be handled here
     public void GetUserAndContinue()
     {
-		string userId = PlayerPrefs.GetString($"userId_{ServerSelect.Name}");
-		if(String.IsNullOrEmpty(userId)) {
-			string userName = $"testUser-{Guid.NewGuid()}";
-			Debug.Log($"No user in player prefs, creating user with username: \"{userName}\"");
-			CreateUser(userName, (user) => {
-				GetCampaignProgresses(user.id, (progresses) => {
-					user.campaignsProgresses = progresses;
-				});
-				PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-				GlobalUserData.Instance.User = user;
-				Debug.Log("User created correctly");
-			});
-		}
-		else {
-			Debug.Log($"Found userid: \"{userId}\" in playerprefs, getting the user");
-			GetUser(userId, (user) => {
-				GetCampaignProgresses(user.id, (progresses) => {
-					user.campaignsProgresses = progresses;
-				});
-				PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
-				GlobalUserData.Instance.User = user;
-			});
-		}
+        string userId = PlayerPrefs.GetString($"userId_{ServerSelect.Name}");
+        if (String.IsNullOrEmpty(userId))
+        {
+            string userName = $"testUser-{Guid.NewGuid()}";
+            Debug.Log($"No user in player prefs, creating user with username: \"{userName}\"");
+            CreateUser(userName, (user) =>
+            {
+                GetCampaignProgresses(user.id, (progresses) =>
+                {
+                    user.campaignsProgresses = progresses;
+                });
+                PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
+                GlobalUserData.Instance.User = user;
+                Debug.Log("User created correctly");
+            });
+        }
+        else
+        {
+            Debug.Log($"Found userid: \"{userId}\" in playerprefs, getting the user");
+            GetUser(userId, (user) =>
+            {
+                GetCampaignProgresses(user.id, (progresses) =>
+                {
+                    user.campaignsProgresses = progresses;
+                });
+                PlayerPrefs.SetString($"userId_{ServerSelect.Name}", user.id);
+                GlobalUserData.Instance.User = user;
+            });
+        }
     }
 
     public void GetUser(string userId, Action<User> onGetUserDataReceived)
     {
-		try{
-			GetUser getUserRequest = new GetUser{
-				UserId = userId
-			};
-			WebSocketRequest request = new WebSocketRequest{
-				GetUser = getUserRequest
-			};
-			currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
-			ws.OnMessage += currentMessageHandler;
-			ws.OnMessage -= OnWebSocketMessage;
-			SendWebSocketMessage(request);
-		} catch(Exception ex) {
-			Debug.LogError(ex.Message);
-		}
+        try
+        {
+            GetUser getUserRequest = new GetUser
+            {
+                UserId = userId
+            };
+            WebSocketRequest request = new WebSocketRequest
+            {
+                GetUser = getUserRequest
+            };
+            currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
+            ws.OnMessage += currentMessageHandler;
+            ws.OnMessage -= OnWebSocketMessage;
+            SendWebSocketMessage(request);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError(ex.Message);
+        }
     }
 
     public void GetUserByUsername(string username, Action<User> onGetUserDataReceived)
     {
-        GetUserByUsername getUserByUsernameRequest = new GetUserByUsername{
+        GetUserByUsername getUserByUsernameRequest = new GetUserByUsername
+        {
             Username = username
         };
-        WebSocketRequest request = new WebSocketRequest{
+        WebSocketRequest request = new WebSocketRequest
+        {
             GetUserByUsername = getUserByUsernameRequest
         };
         currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
@@ -343,21 +366,23 @@ public class SocketConnection : MonoBehaviour {
     {
         try
         {
-			ws.OnMessage -= currentMessageHandler;
-			ws.OnMessage += OnWebSocketMessage;
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
-			{
-				User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-				onGetUserDataReceived?.Invoke(user);
-			}
-			else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
-			{
-                switch(webSocketResponse.Error.Reason) {
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
+            {
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                onGetUserDataReceived?.Invoke(user);
+            }
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
+                switch (webSocketResponse.Error.Reason)
+                {
                     case "not_found":
-						string userName = $"testUser-{Guid.NewGuid()}";
+                        string userName = $"testUser-{Guid.NewGuid()}";
                         Debug.Log($"User not found, trying to create new user with username: \"{userName}\"");
-						CreateUser(userName, (user) => {
+                        CreateUser(userName, (user) =>
+                        {
                             onGetUserDataReceived?.Invoke(user);
                         });
                         break;
@@ -369,17 +394,21 @@ public class SocketConnection : MonoBehaviour {
                         break;
                 }
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             Debug.LogError("InvalidProtocolBufferException: " + e);
         }
     }
 
-	public void CreateUser(string username, Action<User> onGetUserDataReceived)
+    public void CreateUser(string username, Action<User> onGetUserDataReceived)
     {
-        CreateUser createUserRequest = new CreateUser{
+        CreateUser createUserRequest = new CreateUser
+        {
             Username = username
         };
-        WebSocketRequest request = new WebSocketRequest{
+        WebSocketRequest request = new WebSocketRequest
+        {
             CreateUser = createUserRequest
         };
         currentMessageHandler = (data) => AwaitGetUserResponse(data, onGetUserDataReceived);
@@ -388,12 +417,14 @@ public class SocketConnection : MonoBehaviour {
         SendWebSocketMessage(request);
     }
 
-	public void GetCampaignProgresses(string userId, Action<List<(string, string, string)>> onCampaignProgressReceived)
+    public void GetCampaignProgresses(string userId, Action<List<(string, string, string)>> onCampaignProgressReceived)
     {
-        GetUserSuperCampaignProgresses getCampaignsProgressRequest = new GetUserSuperCampaignProgresses{
+        GetUserSuperCampaignProgresses getCampaignsProgressRequest = new GetUserSuperCampaignProgresses
+        {
             UserId = userId
         };
-        WebSocketRequest request = new WebSocketRequest{
+        WebSocketRequest request = new WebSocketRequest
+        {
             GetUserSuperCampaignProgresses = getCampaignsProgressRequest
         };
         currentMessageHandler = (data) => AwaitCampaignsProgressResponse(data, onCampaignProgressReceived);
@@ -402,13 +433,14 @@ public class SocketConnection : MonoBehaviour {
         SendWebSocketMessage(request);
     }
 
-	private void AwaitCampaignsProgressResponse(byte[] data, Action<List<(string, string, string)>> onCampaignProgressReceived)
+    private void AwaitCampaignsProgressResponse(byte[] data, Action<List<(string, string, string)>> onCampaignProgressReceived)
     {
         try
         {
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.SuperCampaignProgresses) {
-				List<(string, string, string)> campaignProgresses = webSocketResponse.SuperCampaignProgresses.SuperCampaignProgresses_.Select(cp => (cp.SuperCampaignId, cp.CampaignId, cp.LevelId)).ToList();
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.SuperCampaignProgresses)
+            {
+                List<(string, string, string)> campaignProgresses = webSocketResponse.SuperCampaignProgresses.SuperCampaignProgresses_.Select(cp => (cp.SuperCampaignName, cp.CampaignId, cp.LevelId)).ToList();
                 onCampaignProgressReceived?.Invoke(campaignProgresses);
             }
         }
@@ -418,30 +450,33 @@ public class SocketConnection : MonoBehaviour {
         }
     }
 
-    public void GetCampaigns(string userId, Action<List<Campaign>> onCampaignDataReceived)
+    public void GetCampaigns(string userId, string superCampaignName, Action<List<Campaign>> onCampaignDataReceived)
     {
-        GetCampaigns getCampaignsRequest = new GetCampaigns{
+        GetCampaigns getCampaignsRequest = new GetCampaigns
+        {
             UserId = userId
         };
-        WebSocketRequest request = new WebSocketRequest{
+        WebSocketRequest request = new WebSocketRequest
+        {
             GetCampaigns = getCampaignsRequest
         };
-        currentMessageHandler = (data) => AwaitGetCampaignsResponse(data, onCampaignDataReceived);
+        currentMessageHandler = (data) => AwaitGetCampaignsResponse(data, onCampaignDataReceived, superCampaignName);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
     }
 
-    private void AwaitGetCampaignsResponse(byte[] data, Action<List<Campaign>> onCampaignDataReceived)
+    private void AwaitGetCampaignsResponse(byte[] data, Action<List<Campaign>> onCampaignDataReceived, string superCampaignName)
     {
         try
         {
-			ws.OnMessage -= currentMessageHandler;
-			ws.OnMessage += OnWebSocketMessage;
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Campaigns) {
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Campaigns)
+            {
                 List<Character> availableCharacters = GlobalUserData.Instance.AvailableCharacters;
-                List<Campaign> campaigns = ParseCampaignsFromResponse(webSocketResponse.Campaigns, availableCharacters);
+                List<Campaign> campaigns = ParseCampaignsFromResponse(webSocketResponse.Campaigns, superCampaignName, availableCharacters);
                 onCampaignDataReceived?.Invoke(campaigns);
             }
         }
@@ -453,12 +488,14 @@ public class SocketConnection : MonoBehaviour {
 
     public void SelectUnit(string unitId, string userId, int slot)
     {
-        SelectUnit selectUnitRequest = new SelectUnit {
+        SelectUnit selectUnitRequest = new SelectUnit
+        {
             UserId = userId,
             UnitId = unitId,
             Slot = (uint)slot
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             SelectUnit = selectUnitRequest
         };
         SendWebSocketMessage(request);
@@ -466,24 +503,27 @@ public class SocketConnection : MonoBehaviour {
 
     public void UnselectUnit(string unitId, string userId)
     {
-        UnselectUnit unselectUnitRequest = new UnselectUnit {
+        UnselectUnit unselectUnitRequest = new UnselectUnit
+        {
             UserId = userId,
             UnitId = unitId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             UnselectUnit = unselectUnitRequest
         };
         SendWebSocketMessage(request);
     }
 
-	private void AwaitBattleResponse(byte[] data, Action<BattleResult> onBattleResultReceived)
+    private void AwaitBattleResponse(byte[] data, Action<BattleResult> onBattleResultReceived)
     {
         try
         {
-			ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage -= currentMessageHandler;
             ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.BattleResult) {
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.BattleResult)
+            {
                 onBattleResultReceived?.Invoke(webSocketResponse.BattleResult);
             }
         }
@@ -493,29 +533,34 @@ public class SocketConnection : MonoBehaviour {
         }
     }
 
-	public IEnumerator Battle(string userId, string levelId, Action<BattleResult> onBattleResultReceived)
-	{
-		FightLevel fightLevelRequest = new FightLevel {
-			UserId = userId,
-			LevelId = levelId
-		};
-		WebSocketRequest request = new WebSocketRequest {
-			FightLevel = fightLevelRequest
-		};
-		currentMessageHandler = (data) => AwaitBattleResponse(data, onBattleResultReceived);
+    public IEnumerator Battle(string userId, string levelId, Action<BattleResult> onBattleResultReceived)
+    {
+        FightLevel fightLevelRequest = new FightLevel
+        {
+            UserId = userId,
+            LevelId = levelId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            FightLevel = fightLevelRequest
+        };
+        currentMessageHandler = (data) => AwaitBattleResponse(data, onBattleResultReceived);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
-		yield return null;
-	}
+        yield return null;
+    }
 
-    public void EquipItem(string userId, string itemId, string unitId, Action<Item> onItemDataReceived) {
-        EquipItem equipItemRequest = new EquipItem {
+    public void EquipItem(string userId, string itemId, string unitId, Action<Item> onItemDataReceived)
+    {
+        EquipItem equipItemRequest = new EquipItem
+        {
             UserId = userId,
             ItemId = itemId,
             UnitId = unitId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             EquipItem = equipItemRequest
         };
         currentMessageHandler = (data) => AwaitItemResponse(data, onItemDataReceived);
@@ -524,12 +569,15 @@ public class SocketConnection : MonoBehaviour {
         SendWebSocketMessage(request);
     }
 
-    public void UnequipItem(string userId, string itemId, Action<Item> onItemDataReceived) {
-        UnequipItem unequipItemRequest = new UnequipItem {
+    public void UnequipItem(string userId, string itemId, Action<Item> onItemDataReceived)
+    {
+        UnequipItem unequipItemRequest = new UnequipItem
+        {
             UserId = userId,
             ItemId = itemId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             UnequipItem = unequipItemRequest
         };
         currentMessageHandler = (data) => AwaitItemResponse(data, onItemDataReceived);
@@ -538,12 +586,15 @@ public class SocketConnection : MonoBehaviour {
         SendWebSocketMessage(request);
     }
 
-    public void LevelUpItem(string userId, string itemId, Action<Item> onItemDataReceived, Action<string> onError) {
-        LevelUpItem levelUpItemRequest = new LevelUpItem {
+    public void LevelUpItem(string userId, string itemId, Action<Item> onItemDataReceived, Action<string> onError)
+    {
+        LevelUpItem levelUpItemRequest = new LevelUpItem
+        {
             UserId = userId,
             ItemId = itemId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             LevelUpItem = levelUpItemRequest
         };
         currentMessageHandler = (data) => AwaitItemResponse(data, onItemDataReceived, onError);
@@ -556,14 +607,16 @@ public class SocketConnection : MonoBehaviour {
     {
         try
         {
-			ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage -= currentMessageHandler;
             ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Item) {
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Item)
+            {
                 Item item = CreateItemFromData(webSocketResponse.Item);
                 onItemDataReceived?.Invoke(item);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }
@@ -573,12 +626,15 @@ public class SocketConnection : MonoBehaviour {
         }
     }
 
-    public void LevelUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError) {
-        LevelUpUnit levelUpUnitRequest = new LevelUpUnit {
+    public void LevelUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError)
+    {
+        LevelUpUnit levelUpUnitRequest = new LevelUpUnit
+        {
             UserId = userId,
             UnitId = unitId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             LevelUpUnit = levelUpUnitRequest
         };
         currentMessageHandler = (data) => AwaitUnitAndCurrenciesReponse(data, onUnitAndCurrenciesDataReceived, onError);
@@ -591,13 +647,15 @@ public class SocketConnection : MonoBehaviour {
     {
         try
         {
-			ws.OnMessage -= currentMessageHandler;
-			ws.OnMessage += OnWebSocketMessage;
+            ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UnitAndCurrencies) {
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UnitAndCurrencies)
+            {
                 onUnitAndCurrenciesDataReceived?.Invoke(webSocketResponse.UnitAndCurrencies);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }
@@ -607,29 +665,33 @@ public class SocketConnection : MonoBehaviour {
         }
     }
 
-	public void GetBoxes(Action<List<Box>> onBoxesDataReceived, Action<string> onError = null) {
-		GetBoxes getBoxesRequest = new GetBoxes();
-        WebSocketRequest request = new WebSocketRequest {
+    public void GetBoxes(Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
+    {
+        GetBoxes getBoxesRequest = new GetBoxes();
+        WebSocketRequest request = new WebSocketRequest
+        {
             GetBoxes = getBoxesRequest
         };
         currentMessageHandler = (data) => AwaitBoxesReponse(data, onBoxesDataReceived, onError);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
-	}
+    }
 
-	private void AwaitBoxesReponse(byte[] data, Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
-	{
-		try
+    private void AwaitBoxesReponse(byte[] data, Action<List<Box>> onBoxesDataReceived, Action<string> onError = null)
+    {
+        try
         {
-			ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage -= currentMessageHandler;
             ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Boxes) {
-				List<Box> boxes = ParseBoxesFromResponse(webSocketResponse.Boxes);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Boxes)
+            {
+                List<Box> boxes = ParseBoxesFromResponse(webSocketResponse.Boxes);
                 onBoxesDataReceived?.Invoke(boxes);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }
@@ -637,51 +699,56 @@ public class SocketConnection : MonoBehaviour {
         {
             Debug.LogError(e.Message);
         }
-	}
+    }
 
-	private List<Box> ParseBoxesFromResponse(Boxes boxesMessage)
-	{
-		return boxesMessage.Boxes_.Select(box => 
-		{
-			return new Box {
-				id = box.Id,
-				name = box.Name,
-				description = box.Description,
-				factions = box.Factions.ToList(),
-				rankWeights = box.RankWeights.ToDictionary(rankWeight => rankWeight.Rank, rankWeight => rankWeight.Weight),
-				costs = box.Cost.ToDictionary(cost => Enum.Parse<Currency>(cost.Currency.Name.Replace(" ", "")), cost => cost.Amount)
-			};
-		}).ToList();
-	}
+    private List<Box> ParseBoxesFromResponse(Boxes boxesMessage)
+    {
+        return boxesMessage.Boxes_.Select(box =>
+        {
+            return new Box
+            {
+                id = box.Id,
+                name = box.Name,
+                description = box.Description,
+                factions = box.Factions.ToList(),
+                rankWeights = box.RankWeights.ToDictionary(rankWeight => rankWeight.Rank, rankWeight => rankWeight.Weight),
+                costs = box.Cost.ToDictionary(cost => Enum.Parse<Currency>(cost.Currency.Name.Replace(" ", "")), cost => cost.Amount)
+            };
+        }).ToList();
+    }
 
-	public void Summon(string userId, string boxId, Action<User, Unit> onSuccess, Action<string> onError = null)
-	{
-		Summon summonRequest = new Summon {
+    public void Summon(string userId, string boxId, Action<User, Unit> onSuccess, Action<string> onError = null)
+    {
+        Summon summonRequest = new Summon
+        {
             UserId = userId,
             BoxId = boxId
         };
-        WebSocketRequest request = new WebSocketRequest {
+        WebSocketRequest request = new WebSocketRequest
+        {
             Summon = summonRequest
         };
         currentMessageHandler = (data) => AwaitSummonResponse(data, onSuccess, onError);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
-	}
+    }
 
-	private void AwaitSummonResponse(byte[] data, Action<User, Unit> onSuccess, Action<string> onError)
-	{
-		try
+    private void AwaitSummonResponse(byte[] data, Action<User, Unit> onSuccess, Action<string> onError)
+    {
+        try
         {
-			ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage -= currentMessageHandler;
             ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UserAndUnit) {
-				User user = CreateUserFromData(webSocketResponse.UserAndUnit.User, GlobalUserData.Instance.AvailableCharacters);
-				Unit unit = CreateUnitFromData(webSocketResponse.UserAndUnit.Unit, GlobalUserData.Instance.AvailableCharacters);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.UserAndUnit)
+            {
+                User user = CreateUserFromData(webSocketResponse.UserAndUnit.User, GlobalUserData.Instance.AvailableCharacters);
+                Unit unit = CreateUnitFromData(webSocketResponse.UserAndUnit.Unit, GlobalUserData.Instance.AvailableCharacters);
                 onSuccess?.Invoke(user, unit);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }
@@ -689,39 +756,44 @@ public class SocketConnection : MonoBehaviour {
         {
             Debug.LogError(e.Message);
         }
-	}
+    }
 
-	public void FuseUnits(string userId, string unitId, string[] consumedUnitsIds, Action<Unit> onSuccess, Action<string> onError = null)
-	{
-		FuseUnit fuseRequest = new FuseUnit {
+    public void FuseUnits(string userId, string unitId, string[] consumedUnitsIds, Action<Unit> onSuccess, Action<string> onError = null)
+    {
+        FuseUnit fuseRequest = new FuseUnit
+        {
             UserId = userId,
             UnitId = unitId,
         };
-		// Why on earth repeated fields don't have a setter but you can still add values to them?
-		foreach(string consumedUnitId in consumedUnitsIds) {
-			fuseRequest.ConsumedUnitsIds.Add(consumedUnitId);
-		}
-        WebSocketRequest request = new WebSocketRequest {
+        // Why on earth repeated fields don't have a setter but you can still add values to them?
+        foreach (string consumedUnitId in consumedUnitsIds)
+        {
+            fuseRequest.ConsumedUnitsIds.Add(consumedUnitId);
+        }
+        WebSocketRequest request = new WebSocketRequest
+        {
             FuseUnit = fuseRequest
         };
         currentMessageHandler = (data) => AwaitFuseUnitsResponse(data, onSuccess, onError);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
-	}
+    }
 
-	private void AwaitFuseUnitsResponse(byte[] data, Action<Unit> onSuccess, Action<string> onError)
-	{
-		try
+    private void AwaitFuseUnitsResponse(byte[] data, Action<Unit> onSuccess, Action<string> onError)
+    {
+        try
         {
-			ws.OnMessage -= currentMessageHandler;
+            ws.OnMessage -= currentMessageHandler;
             ws.OnMessage += OnWebSocketMessage;
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
-            if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Unit) {
-				Unit unit = CreateUnitFromData(webSocketResponse.Unit, GlobalUserData.Instance.AvailableCharacters);
+            if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Unit)
+            {
+                Unit unit = CreateUnitFromData(webSocketResponse.Unit, GlobalUserData.Instance.AvailableCharacters);
                 onSuccess?.Invoke(unit);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }
@@ -729,7 +801,7 @@ public class SocketConnection : MonoBehaviour {
         {
             Debug.LogError(e.Message);
         }
-	}
+    }
 
     private Dictionary<Currency, int> GetLevelCurrencyRewards(Level level)
     {
@@ -770,7 +842,8 @@ public class SocketConnection : MonoBehaviour {
                 }).ToList();
                 onAfkRewardsReceived?.Invoke(afkRewards);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
 
@@ -806,10 +879,11 @@ public class SocketConnection : MonoBehaviour {
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
             if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
             {
-				User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
-				onAfkRewardsReceived?.Invoke(user);
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                onAfkRewardsReceived?.Invoke(user);
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
 
@@ -830,7 +904,7 @@ public class SocketConnection : MonoBehaviour {
         {
             LevelUpKalineTree = levelUpKalineTreeRequest
         };
-        currentMessageHandler = (data) => AwaitLevelUpKalineTreeResponse(data, onLeveledUpUserReceived, onError); 
+        currentMessageHandler = (data) => AwaitLevelUpKalineTreeResponse(data, onLeveledUpUserReceived, onError);
         ws.OnMessage += currentMessageHandler;
         ws.OnMessage -= OnWebSocketMessage;
         SendWebSocketMessage(request);
@@ -845,11 +919,12 @@ public class SocketConnection : MonoBehaviour {
             WebSocketResponse webSocketResponse = WebSocketResponse.Parser.ParseFrom(data);
             if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.User)
             {
-				User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
+                User user = CreateUserFromData(webSocketResponse.User, GlobalUserData.Instance.AvailableCharacters);
                 onLeveledUpUserReceived?.Invoke(user);
                 GlobalUserData.Instance.User.kalineTreeLevel = user.kalineTreeLevel;
             }
-            else if(webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error) {
+            else if (webSocketResponse.ResponseTypeCase == WebSocketResponse.ResponseTypeOneofCase.Error)
+            {
                 onError?.Invoke(webSocketResponse.Error.Reason);
             }
         }

--- a/client/Assets/Scripts/CampaignsMap/CampaignsMapManager.cs
+++ b/client/Assets/Scripts/CampaignsMap/CampaignsMapManager.cs
@@ -28,10 +28,8 @@ public class CampaignsMapManager : MonoBehaviour
         // Currently we have 2 campaigns and the client is hardcoded to only manage 2 campaigns, TODO: variable number of campaigns
         for (int campaignsIndex = 0; campaignsIndex < 2; campaignsIndex++)
         {
-            for (int campaignsIndex = 0; campaignsIndex < 2; campaignsIndex++)
-            {
-                campaignItems[campaignsIndex].sceneManager = sceneManager;
-                campaignItems[campaignsIndex].SetCampaignData(campaigns[campaignsIndex]);
-            }
+            campaignItems[campaignsIndex].sceneManager = sceneManager;
+            campaignItems[campaignsIndex].SetCampaignData(campaigns[campaignsIndex]);
         }
     }
+}

--- a/client/Assets/Scripts/CampaignsMap/CampaignsMapManager.cs
+++ b/client/Assets/Scripts/CampaignsMap/CampaignsMapManager.cs
@@ -11,11 +11,14 @@ public class CampaignsMapManager : MonoBehaviour
     [SerializeField]
     LevelManager sceneManager;
 
+    public static string selectedSuperCampaign;
+
     void Start()
     {
-        SocketConnection.Instance.GetCampaigns(GlobalUserData.Instance.User.id, (campaigns) => {
-			// this needs to be refactored, the campaigns have two parallel "paths" that do different things, they should be unified into the static class
-			LevelProgress.campaigns = campaigns;
+        SocketConnection.Instance.GetCampaigns(GlobalUserData.Instance.User.id, selectedSuperCampaign, (campaigns) =>
+        {
+            // this needs to be refactored, the campaigns have two parallel "paths" that do different things, they should be unified into the static class
+            LevelProgress.campaigns = campaigns;
             GenerateCampaigns(campaigns);
         });
     }
@@ -23,7 +26,8 @@ public class CampaignsMapManager : MonoBehaviour
     private void GenerateCampaigns(List<Campaign> campaigns)
     {
         // Currently we have 2 campaigns and the client is hardcoded to only manage 2 campaigns, TODO: variable number of campaigns
-        for(int campaignsIndex = 0; campaignsIndex < 2; campaignsIndex++) {
+        for (int campaignsIndex = 0; campaignsIndex < 2; campaignsIndex++)
+        {
             campaignItems[campaignsIndex].sceneManager = sceneManager;
             campaignItems[campaignsIndex].SetCampaignData(campaigns[campaignsIndex]);
         }

--- a/client/Assets/Scripts/Protobuf/Gateway.pb.cs
+++ b/client/Assets/Scripts/Protobuf/Gateway.pb.cs
@@ -89,75 +89,75 @@ namespace Protobuf.Messages {
             "ZWxfdXBfY29zdBgEIAEoBBIXCg91bmxvY2tfZmVhdHVyZXMYBSADKAkSKAoQ",
             "YWZrX3Jld2FyZF9yYXRlcxgGIAMoCzIOLkFma1Jld2FyZFJhdGUiVAoXU3Vw",
             "ZXJDYW1wYWlnblByb2dyZXNzZXMSOQoZc3VwZXJfY2FtcGFpZ25fcHJvZ3Jl",
-            "c3NlcxgBIAMoCzIWLlN1cGVyQ2FtcGFpZ25Qcm9ncmVzcyJqChVTdXBlckNh",
+            "c3NlcxgBIAMoCzIWLlN1cGVyQ2FtcGFpZ25Qcm9ncmVzcyJsChVTdXBlckNh",
             "bXBhaWduUHJvZ3Jlc3MSDwoHdXNlcl9pZBgBIAEoCRITCgtjYW1wYWlnbl9p",
-            "ZBgCIAEoCRIQCghsZXZlbF9pZBgDIAEoCRIZChFzdXBlcl9jYW1wYWlnbl9p",
-            "ZBgEIAEoCSJYCg1BZmtSZXdhcmRSYXRlEhwKFGthbGluZV90cmVlX2xldmVs",
-            "X2lkGAEgASgJEhsKCGN1cnJlbmN5GAIgASgLMgkuQ3VycmVuY3kSDAoEcmF0",
-            "ZRgDIAEoAiI7CgxVc2VyQ3VycmVuY3kSGwoIY3VycmVuY3kYASABKAsyCS5D",
-            "dXJyZW5jeRIOCgZhbW91bnQYAiABKA0iGAoIQ3VycmVuY3kSDAoEbmFtZRgB",
-            "IAEoCSK+AQoEVW5pdBIKCgJpZBgBIAEoCRINCgVsZXZlbBgCIAEoDRIMCgR0",
-            "aWVyGAMgASgNEgwKBHJhbmsYBCABKA0SEAoIc2VsZWN0ZWQYBSABKAgSDAoE",
-            "c2xvdBgGIAEoDRIZChFjYW1wYWlnbl9sZXZlbF9pZBgHIAEoCRIPCgd1c2Vy",
-            "X2lkGAggASgJEh0KCWNoYXJhY3RlchgJIAEoCzIKLkNoYXJhY3RlchIUCgVp",
-            "dGVtcxgKIAMoCzIFLkl0ZW0iHQoFVW5pdHMSFAoFdW5pdHMYASADKAsyBS5V",
-            "bml0Ik4KEVVuaXRBbmRDdXJyZW5jaWVzEhMKBHVuaXQYASABKAsyBS5Vbml0",
-            "EiQKDXVzZXJfY3VycmVuY3kYAiADKAsyDS5Vc2VyQ3VycmVuY3kiSwoJQ2hh",
-            "cmFjdGVyEg4KBmFjdGl2ZRgBIAEoCBIMCgRuYW1lGAIgASgJEg8KB2ZhY3Rp",
-            "b24YAyABKAkSDwoHcXVhbGl0eRgEIAEoDSJkCgRJdGVtEgoKAmlkGAEgASgJ",
-            "Eg0KBWxldmVsGAIgASgNEh8KCHRlbXBsYXRlGAMgASgLMg0uSXRlbVRlbXBs",
-            "YXRlEg8KB3VzZXJfaWQYBCABKAkSDwoHdW5pdF9pZBgFIAEoCSI2CgxJdGVt",
-            "VGVtcGxhdGUSCgoCaWQYASABKAkSDAoEbmFtZRgCIAEoCRIMCgR0eXBlGAMg",
-            "ASgJIikKCUNhbXBhaWducxIcCgljYW1wYWlnbnMYASADKAsyCS5DYW1wYWln",
-            "biJiCghDYW1wYWlnbhIKCgJpZBgBIAEoCRIZChFzdXBlcl9jYW1wYWlnbl9p",
-            "ZBgCIAEoCRIXCg9jYW1wYWlnbl9udW1iZXIYAyABKA0SFgoGbGV2ZWxzGAQg",
-            "AygLMgYuTGV2ZWwimgEKBUxldmVsEgoKAmlkGAEgASgJEhMKC2NhbXBhaWdu",
-            "X2lkGAIgASgJEhQKDGxldmVsX251bWJlchgDIAEoDRIUCgV1bml0cxgEIAMo",
-            "CzIFLlVuaXQSKQoQY3VycmVuY3lfcmV3YXJkcxgFIAMoCzIPLkN1cnJlbmN5",
-            "UmV3YXJkEhkKEWV4cGVyaWVuY2VfcmV3YXJkGAYgASgNIj0KDkN1cnJlbmN5",
-            "UmV3YXJkEhsKCGN1cnJlbmN5GAEgASgLMgkuQ3VycmVuY3kSDgoGYW1vdW50",
-            "GAMgASgEIi0KCkFma1Jld2FyZHMSHwoLYWZrX3Jld2FyZHMYASADKAsyCi5B",
-            "ZmtSZXdhcmQiOAoJQWZrUmV3YXJkEhsKCGN1cnJlbmN5GAEgASgLMgkuQ3Vy",
-            "cmVuY3kSDgoGYW1vdW50GAIgASgEIhcKBUVycm9yEg4KBnJlYXNvbhgBIAEo",
-            "CSIcCgVCb3hlcxITCgVib3hlcxgBIAMoCzIELkJveCKHAQoDQm94EgoKAmlk",
-            "GAEgASgJEgwKBG5hbWUYAiABKAkSEwoLZGVzY3JpcHRpb24YAyABKAkSEAoI",
-            "ZmFjdGlvbnMYBCADKAkSIgoMcmFua193ZWlnaHRzGAUgAygLMgwuUmFua1dl",
-            "aWdodHMSGwoEY29zdBgGIAMoCzINLkN1cnJlbmN5Q29zdCIrCgtSYW5rV2Vp",
-            "Z2h0cxIMCgRyYW5rGAEgASgFEg4KBndlaWdodBgCIAEoBSI7CgxDdXJyZW5j",
-            "eUNvc3QSGwoIY3VycmVuY3kYASABKAsyCS5DdXJyZW5jeRIOCgZhbW91bnQY",
-            "AiABKAUiNwoLVXNlckFuZFVuaXQSEwoEdXNlchgBIAEoCzIFLlVzZXISEwoE",
-            "dW5pdBgCIAEoCzIFLlVuaXQiUwoMQmF0dGxlUmVzdWx0Eh0KDWluaXRpYWxf",
-            "c3RhdGUYASABKAsyBi5TdGF0ZRIUCgVzdGVwcxgCIAMoCzIFLlN0ZXASDgoG",
-            "cmVzdWx0GAMgASgJIiMKBVN0YXRlEhoKBXVuaXRzGAEgAygLMgsuQmF0dGxl",
-            "VW5pdCJaCgpCYXR0bGVVbml0EgoKAmlkGAEgASgJEg4KBmhlYWx0aBgCIAEo",
-            "BRIMCgRzbG90GAMgASgFEhQKDGNoYXJhY3Rlcl9pZBgEIAEoCRIMCgR0ZWFt",
-            "GAUgASgFIjUKBFN0ZXASEwoLc3RlcF9udW1iZXIYASABKAUSGAoHYWN0aW9u",
-            "cxgCIAMoCzIHLkFjdGlvbiKwAgoGQWN0aW9uEiQKDHNraWxsX2FjdGlvbhgB",
-            "IAEoCzIMLlNraWxsQWN0aW9uSAASLgoRbW9kaWZpZXJfcmVjZWl2ZWQYAiAB",
-            "KAsyES5Nb2RpZmllclJlY2VpdmVkSAASJAoMdGFnX3JlY2VpdmVkGAMgASgL",
-            "MgwuVGFnUmVjZWl2ZWRIABIsChBtb2RpZmllcl9leHBpcmVkGAQgASgLMhAu",
-            "TW9kaWZpZXJFeHBpcmVkSAASIgoLdGFnX2V4cGlyZWQYBSABKAsyCy5UYWdF",
-            "eHBpcmVkSAASFwoFZGVhdGgYBiABKAsyBi5EZWF0aEgAEjAKEmV4ZWN1dGlv",
-            "bl9yZWNlaXZlZBgHIAEoCzISLkV4ZWN1dGlvblJlY2VpdmVkSABCDQoLYWN0",
-            "aW9uX3R5cGUiMwoMU3RhdEFmZmVjdGVkEhMKBHN0YXQYASABKA4yBS5TdGF0",
-            "Eg4KBmFtb3VudBgCIAEoAiJzCgtTa2lsbEFjdGlvbhIRCgljYXN0ZXJfaWQY",
-            "ASABKAkSEgoKdGFyZ2V0X2lkcxgCIAMoCRIQCghza2lsbF9pZBgDIAEoCRIr",
-            "ChFza2lsbF9hY3Rpb25fdHlwZRgEIAEoDjIQLlNraWxsQWN0aW9uVHlwZSJM",
-            "ChFFeGVjdXRpb25SZWNlaXZlZBIRCgl0YXJnZXRfaWQYASABKAkSJAoNc3Rh",
-            "dF9hZmZlY3RlZBgCIAEoCzINLlN0YXRBZmZlY3RlZCJdChBNb2RpZmllclJl",
-            "Y2VpdmVkEhAKCHNraWxsX2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIk",
-            "Cg1zdGF0X2FmZmVjdGVkGAMgASgLMg0uU3RhdEFmZmVjdGVkIkQKC1RhZ1Jl",
-            "Y2VpdmVkEhAKCHNraWxsX2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIQ",
-            "Cgh0YWdfbmFtZRgDIAEoCSJcCg9Nb2RpZmllckV4cGlyZWQSEAoIc2tpbGxf",
-            "aWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJEiQKDXN0YXRfYWZmZWN0ZWQY",
-            "AyABKAsyDS5TdGF0QWZmZWN0ZWQiQwoKVGFnRXhwaXJlZBIQCghza2lsbF9p",
-            "ZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiABKAkSEAoIdGFnX25hbWUYAyABKAki",
-            "GAoFRGVhdGgSDwoHdW5pdF9pZBgBIAEoCSpbCg9Ta2lsbEFjdGlvblR5cGUS",
-            "EwoPQU5JTUFUSU9OX1NUQVJUEAASEgoORUZGRUNUX1RSSUdHRVIQARIOCgpF",
-            "RkZFQ1RfSElUEAISDwoLRUZGRUNUX01JU1MQAypYCgRTdGF0EgoKBkhFQUxU",
-            "SBAAEgoKBkVORVJHWRABEgoKBkFUVEFDSxACEgsKB0RFRkVOU0UQAxIUChBE",
-            "QU1BR0VfUkVEVUNUSU9OEAQSCQoFU1BFRUQQBUIUqgIRUHJvdG9idWYuTWVz",
-            "c2FnZXNiBnByb3RvMw=="));
+            "ZBgCIAEoCRIQCghsZXZlbF9pZBgDIAEoCRIbChNzdXBlcl9jYW1wYWlnbl9u",
+            "YW1lGAQgASgJIlgKDUFma1Jld2FyZFJhdGUSHAoUa2FsaW5lX3RyZWVfbGV2",
+            "ZWxfaWQYASABKAkSGwoIY3VycmVuY3kYAiABKAsyCS5DdXJyZW5jeRIMCgRy",
+            "YXRlGAMgASgCIjsKDFVzZXJDdXJyZW5jeRIbCghjdXJyZW5jeRgBIAEoCzIJ",
+            "LkN1cnJlbmN5Eg4KBmFtb3VudBgCIAEoDSIYCghDdXJyZW5jeRIMCgRuYW1l",
+            "GAEgASgJIr4BCgRVbml0EgoKAmlkGAEgASgJEg0KBWxldmVsGAIgASgNEgwK",
+            "BHRpZXIYAyABKA0SDAoEcmFuaxgEIAEoDRIQCghzZWxlY3RlZBgFIAEoCBIM",
+            "CgRzbG90GAYgASgNEhkKEWNhbXBhaWduX2xldmVsX2lkGAcgASgJEg8KB3Vz",
+            "ZXJfaWQYCCABKAkSHQoJY2hhcmFjdGVyGAkgASgLMgouQ2hhcmFjdGVyEhQK",
+            "BWl0ZW1zGAogAygLMgUuSXRlbSIdCgVVbml0cxIUCgV1bml0cxgBIAMoCzIF",
+            "LlVuaXQiTgoRVW5pdEFuZEN1cnJlbmNpZXMSEwoEdW5pdBgBIAEoCzIFLlVu",
+            "aXQSJAoNdXNlcl9jdXJyZW5jeRgCIAMoCzINLlVzZXJDdXJyZW5jeSJLCglD",
+            "aGFyYWN0ZXISDgoGYWN0aXZlGAEgASgIEgwKBG5hbWUYAiABKAkSDwoHZmFj",
+            "dGlvbhgDIAEoCRIPCgdxdWFsaXR5GAQgASgNImQKBEl0ZW0SCgoCaWQYASAB",
+            "KAkSDQoFbGV2ZWwYAiABKA0SHwoIdGVtcGxhdGUYAyABKAsyDS5JdGVtVGVt",
+            "cGxhdGUSDwoHdXNlcl9pZBgEIAEoCRIPCgd1bml0X2lkGAUgASgJIjYKDEl0",
+            "ZW1UZW1wbGF0ZRIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEgwKBHR5cGUY",
+            "AyABKAkiKQoJQ2FtcGFpZ25zEhwKCWNhbXBhaWducxgBIAMoCzIJLkNhbXBh",
+            "aWduImIKCENhbXBhaWduEgoKAmlkGAEgASgJEhkKEXN1cGVyX2NhbXBhaWdu",
+            "X2lkGAIgASgJEhcKD2NhbXBhaWduX251bWJlchgDIAEoDRIWCgZsZXZlbHMY",
+            "BCADKAsyBi5MZXZlbCKaAQoFTGV2ZWwSCgoCaWQYASABKAkSEwoLY2FtcGFp",
+            "Z25faWQYAiABKAkSFAoMbGV2ZWxfbnVtYmVyGAMgASgNEhQKBXVuaXRzGAQg",
+            "AygLMgUuVW5pdBIpChBjdXJyZW5jeV9yZXdhcmRzGAUgAygLMg8uQ3VycmVu",
+            "Y3lSZXdhcmQSGQoRZXhwZXJpZW5jZV9yZXdhcmQYBiABKA0iPQoOQ3VycmVu",
+            "Y3lSZXdhcmQSGwoIY3VycmVuY3kYASABKAsyCS5DdXJyZW5jeRIOCgZhbW91",
+            "bnQYAyABKAQiLQoKQWZrUmV3YXJkcxIfCgthZmtfcmV3YXJkcxgBIAMoCzIK",
+            "LkFma1Jld2FyZCI4CglBZmtSZXdhcmQSGwoIY3VycmVuY3kYASABKAsyCS5D",
+            "dXJyZW5jeRIOCgZhbW91bnQYAiABKAQiFwoFRXJyb3ISDgoGcmVhc29uGAEg",
+            "ASgJIhwKBUJveGVzEhMKBWJveGVzGAEgAygLMgQuQm94IocBCgNCb3gSCgoC",
+            "aWQYASABKAkSDAoEbmFtZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIQ",
+            "CghmYWN0aW9ucxgEIAMoCRIiCgxyYW5rX3dlaWdodHMYBSADKAsyDC5SYW5r",
+            "V2VpZ2h0cxIbCgRjb3N0GAYgAygLMg0uQ3VycmVuY3lDb3N0IisKC1JhbmtX",
+            "ZWlnaHRzEgwKBHJhbmsYASABKAUSDgoGd2VpZ2h0GAIgASgFIjsKDEN1cnJl",
+            "bmN5Q29zdBIbCghjdXJyZW5jeRgBIAEoCzIJLkN1cnJlbmN5Eg4KBmFtb3Vu",
+            "dBgCIAEoBSI3CgtVc2VyQW5kVW5pdBITCgR1c2VyGAEgASgLMgUuVXNlchIT",
+            "CgR1bml0GAIgASgLMgUuVW5pdCJTCgxCYXR0bGVSZXN1bHQSHQoNaW5pdGlh",
+            "bF9zdGF0ZRgBIAEoCzIGLlN0YXRlEhQKBXN0ZXBzGAIgAygLMgUuU3RlcBIO",
+            "CgZyZXN1bHQYAyABKAkiIwoFU3RhdGUSGgoFdW5pdHMYASADKAsyCy5CYXR0",
+            "bGVVbml0IloKCkJhdHRsZVVuaXQSCgoCaWQYASABKAkSDgoGaGVhbHRoGAIg",
+            "ASgFEgwKBHNsb3QYAyABKAUSFAoMY2hhcmFjdGVyX2lkGAQgASgJEgwKBHRl",
+            "YW0YBSABKAUiNQoEU3RlcBITCgtzdGVwX251bWJlchgBIAEoBRIYCgdhY3Rp",
+            "b25zGAIgAygLMgcuQWN0aW9uIrACCgZBY3Rpb24SJAoMc2tpbGxfYWN0aW9u",
+            "GAEgASgLMgwuU2tpbGxBY3Rpb25IABIuChFtb2RpZmllcl9yZWNlaXZlZBgC",
+            "IAEoCzIRLk1vZGlmaWVyUmVjZWl2ZWRIABIkCgx0YWdfcmVjZWl2ZWQYAyAB",
+            "KAsyDC5UYWdSZWNlaXZlZEgAEiwKEG1vZGlmaWVyX2V4cGlyZWQYBCABKAsy",
+            "EC5Nb2RpZmllckV4cGlyZWRIABIiCgt0YWdfZXhwaXJlZBgFIAEoCzILLlRh",
+            "Z0V4cGlyZWRIABIXCgVkZWF0aBgGIAEoCzIGLkRlYXRoSAASMAoSZXhlY3V0",
+            "aW9uX3JlY2VpdmVkGAcgASgLMhIuRXhlY3V0aW9uUmVjZWl2ZWRIAEINCgth",
+            "Y3Rpb25fdHlwZSIzCgxTdGF0QWZmZWN0ZWQSEwoEc3RhdBgBIAEoDjIFLlN0",
+            "YXQSDgoGYW1vdW50GAIgASgCInMKC1NraWxsQWN0aW9uEhEKCWNhc3Rlcl9p",
+            "ZBgBIAEoCRISCgp0YXJnZXRfaWRzGAIgAygJEhAKCHNraWxsX2lkGAMgASgJ",
+            "EisKEXNraWxsX2FjdGlvbl90eXBlGAQgASgOMhAuU2tpbGxBY3Rpb25UeXBl",
+            "IkwKEUV4ZWN1dGlvblJlY2VpdmVkEhEKCXRhcmdldF9pZBgBIAEoCRIkCg1z",
+            "dGF0X2FmZmVjdGVkGAIgASgLMg0uU3RhdEFmZmVjdGVkIl0KEE1vZGlmaWVy",
+            "UmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJ",
+            "EiQKDXN0YXRfYWZmZWN0ZWQYAyABKAsyDS5TdGF0QWZmZWN0ZWQiRAoLVGFn",
+            "UmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJ",
+            "EhAKCHRhZ19uYW1lGAMgASgJIlwKD01vZGlmaWVyRXhwaXJlZBIQCghza2ls",
+            "bF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiABKAkSJAoNc3RhdF9hZmZlY3Rl",
+            "ZBgDIAEoCzINLlN0YXRBZmZlY3RlZCJDCgpUYWdFeHBpcmVkEhAKCHNraWxs",
+            "X2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIQCgh0YWdfbmFtZRgDIAEo",
+            "CSIYCgVEZWF0aBIPCgd1bml0X2lkGAEgASgJKlsKD1NraWxsQWN0aW9uVHlw",
+            "ZRITCg9BTklNQVRJT05fU1RBUlQQABISCg5FRkZFQ1RfVFJJR0dFUhABEg4K",
+            "CkVGRkVDVF9ISVQQAhIPCgtFRkZFQ1RfTUlTUxADKlgKBFN0YXQSCgoGSEVB",
+            "TFRIEAASCgoGRU5FUkdZEAESCgoGQVRUQUNLEAISCwoHREVGRU5TRRADEhQK",
+            "EERBTUFHRV9SRURVQ1RJT04QBBIJCgVTUEVFRBAFQhSqAhFQcm90b2J1Zi5N",
+            "ZXNzYWdlc2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Protobuf.Messages.SkillActionType), typeof(global::Protobuf.Messages.Stat), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -189,7 +189,7 @@ namespace Protobuf.Messages {
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.User), global::Protobuf.Messages.User.Parser, new[]{ "Id", "Username", "Level", "Experience", "Currencies", "Units", "Items", "KalineTreeLevel" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.KalineTreeLevel), global::Protobuf.Messages.KalineTreeLevel.Parser, new[]{ "Id", "Level", "FertilizerLevelUpCost", "GoldLevelUpCost", "UnlockFeatures", "AfkRewardRates" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.SuperCampaignProgresses), global::Protobuf.Messages.SuperCampaignProgresses.Parser, new[]{ "SuperCampaignProgresses_" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.SuperCampaignProgress), global::Protobuf.Messages.SuperCampaignProgress.Parser, new[]{ "UserId", "CampaignId", "LevelId", "SuperCampaignId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.SuperCampaignProgress), global::Protobuf.Messages.SuperCampaignProgress.Parser, new[]{ "UserId", "CampaignId", "LevelId", "SuperCampaignName" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.AfkRewardRate), global::Protobuf.Messages.AfkRewardRate.Parser, new[]{ "KalineTreeLevelId", "Currency", "Rate" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.UserCurrency), global::Protobuf.Messages.UserCurrency.Parser, new[]{ "Currency", "Amount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Currency), global::Protobuf.Messages.Currency.Parser, new[]{ "Name" }, null, null, null, null),
@@ -8569,7 +8569,7 @@ namespace Protobuf.Messages {
       userId_ = other.userId_;
       campaignId_ = other.campaignId_;
       levelId_ = other.levelId_;
-      superCampaignId_ = other.superCampaignId_;
+      superCampaignName_ = other.superCampaignName_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -8615,15 +8615,15 @@ namespace Protobuf.Messages {
       }
     }
 
-    /// <summary>Field number for the "super_campaign_id" field.</summary>
-    public const int SuperCampaignIdFieldNumber = 4;
-    private string superCampaignId_ = "";
+    /// <summary>Field number for the "super_campaign_name" field.</summary>
+    public const int SuperCampaignNameFieldNumber = 4;
+    private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignId {
-      get { return superCampaignId_; }
+    public string SuperCampaignName {
+      get { return superCampaignName_; }
       set {
-        superCampaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -8645,7 +8645,7 @@ namespace Protobuf.Messages {
       if (UserId != other.UserId) return false;
       if (CampaignId != other.CampaignId) return false;
       if (LevelId != other.LevelId) return false;
-      if (SuperCampaignId != other.SuperCampaignId) return false;
+      if (SuperCampaignName != other.SuperCampaignName) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -8656,7 +8656,7 @@ namespace Protobuf.Messages {
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (CampaignId.Length != 0) hash ^= CampaignId.GetHashCode();
       if (LevelId.Length != 0) hash ^= LevelId.GetHashCode();
-      if (SuperCampaignId.Length != 0) hash ^= SuperCampaignId.GetHashCode();
+      if (SuperCampaignName.Length != 0) hash ^= SuperCampaignName.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -8687,9 +8687,9 @@ namespace Protobuf.Messages {
         output.WriteRawTag(26);
         output.WriteString(LevelId);
       }
-      if (SuperCampaignId.Length != 0) {
+      if (SuperCampaignName.Length != 0) {
         output.WriteRawTag(34);
-        output.WriteString(SuperCampaignId);
+        output.WriteString(SuperCampaignName);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -8713,9 +8713,9 @@ namespace Protobuf.Messages {
         output.WriteRawTag(26);
         output.WriteString(LevelId);
       }
-      if (SuperCampaignId.Length != 0) {
+      if (SuperCampaignName.Length != 0) {
         output.WriteRawTag(34);
-        output.WriteString(SuperCampaignId);
+        output.WriteString(SuperCampaignName);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -8736,8 +8736,8 @@ namespace Protobuf.Messages {
       if (LevelId.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(LevelId);
       }
-      if (SuperCampaignId.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignId);
+      if (SuperCampaignName.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -8760,8 +8760,8 @@ namespace Protobuf.Messages {
       if (other.LevelId.Length != 0) {
         LevelId = other.LevelId;
       }
-      if (other.SuperCampaignId.Length != 0) {
-        SuperCampaignId = other.SuperCampaignId;
+      if (other.SuperCampaignName.Length != 0) {
+        SuperCampaignName = other.SuperCampaignName;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -8791,7 +8791,7 @@ namespace Protobuf.Messages {
             break;
           }
           case 34: {
-            SuperCampaignId = input.ReadString();
+            SuperCampaignName = input.ReadString();
             break;
           }
         }
@@ -8822,7 +8822,7 @@ namespace Protobuf.Messages {
             break;
           }
           case 34: {
-            SuperCampaignId = input.ReadString();
+            SuperCampaignName = input.ReadString();
             break;
           }
         }

--- a/client/Assets/Scripts/Protobuf/Gateway.pb.cs
+++ b/client/Assets/Scripts/Protobuf/Gateway.pb.cs
@@ -95,78 +95,78 @@ namespace Protobuf.Messages
             "ZXJDYW1wYWlnblByb2dyZXNzZXMSOQoZc3VwZXJfY2FtcGFpZ25fcHJvZ3Jl",
             "c3NlcxgBIAMoCzIWLlN1cGVyQ2FtcGFpZ25Qcm9ncmVzcyJsChVTdXBlckNh",
             "bXBhaWduUHJvZ3Jlc3MSDwoHdXNlcl9pZBgBIAEoCRITCgtjYW1wYWlnbl9p",
-            "ZBgCIAEoCRIQCghsZXZlbF9pZBgDIAEoCRIZChFzdXBlcl9jYW1wYWlnbl9p",
-            "ZBgEIAEoCSJYCg1BZmtSZXdhcmRSYXRlEhwKFGthbGluZV90cmVlX2xldmVs",
-            "X2lkGAEgASgJEhsKCGN1cnJlbmN5GAIgASgLMgkuQ3VycmVuY3kSDAoEcmF0",
-            "ZRgDIAEoAiI7CgxVc2VyQ3VycmVuY3kSGwoIY3VycmVuY3kYASABKAsyCS5D",
-            "dXJyZW5jeRIOCgZhbW91bnQYAiABKA0iGAoIQ3VycmVuY3kSDAoEbmFtZRgB",
-            "IAEoCSK+AQoEVW5pdBIKCgJpZBgBIAEoCRINCgVsZXZlbBgCIAEoDRIMCgR0",
-            "aWVyGAMgASgNEgwKBHJhbmsYBCABKA0SEAoIc2VsZWN0ZWQYBSABKAgSDAoE",
-            "c2xvdBgGIAEoDRIZChFjYW1wYWlnbl9sZXZlbF9pZBgHIAEoCRIPCgd1c2Vy",
-            "X2lkGAggASgJEh0KCWNoYXJhY3RlchgJIAEoCzIKLkNoYXJhY3RlchIUCgVp",
-            "dGVtcxgKIAMoCzIFLkl0ZW0iHQoFVW5pdHMSFAoFdW5pdHMYASADKAsyBS5V",
-            "bml0Ik4KEVVuaXRBbmRDdXJyZW5jaWVzEhMKBHVuaXQYASABKAsyBS5Vbml0",
-            "EiQKDXVzZXJfY3VycmVuY3kYAiADKAsyDS5Vc2VyQ3VycmVuY3kiSwoJQ2hh",
-            "cmFjdGVyEg4KBmFjdGl2ZRgBIAEoCBIMCgRuYW1lGAIgASgJEg8KB2ZhY3Rp",
-            "b24YAyABKAkSDwoHcXVhbGl0eRgEIAEoDSJkCgRJdGVtEgoKAmlkGAEgASgJ",
-            "Eg0KBWxldmVsGAIgASgNEh8KCHRlbXBsYXRlGAMgASgLMg0uSXRlbVRlbXBs",
-            "YXRlEg8KB3VzZXJfaWQYBCABKAkSDwoHdW5pdF9pZBgFIAEoCSI2CgxJdGVt",
-            "VGVtcGxhdGUSCgoCaWQYASABKAkSDAoEbmFtZRgCIAEoCRIMCgR0eXBlGAMg",
-            "ASgJIikKCUNhbXBhaWducxIcCgljYW1wYWlnbnMYASADKAsyCS5DYW1wYWln",
-            "biJiCghDYW1wYWlnbhIKCgJpZBgBIAEoCRIZChFzdXBlcl9jYW1wYWlnbl9p",
-            "ZBgCIAEoCRIXCg9jYW1wYWlnbl9udW1iZXIYAyABKA0SFgoGbGV2ZWxzGAQg",
-            "AygLMgYuTGV2ZWwimgEKBUxldmVsEgoKAmlkGAEgASgJEhMKC2NhbXBhaWdu",
-            "X2lkGAIgASgJEhQKDGxldmVsX251bWJlchgDIAEoDRIUCgV1bml0cxgEIAMo",
-            "CzIFLlVuaXQSKQoQY3VycmVuY3lfcmV3YXJkcxgFIAMoCzIPLkN1cnJlbmN5",
-            "UmV3YXJkEhkKEWV4cGVyaWVuY2VfcmV3YXJkGAYgASgNIj0KDkN1cnJlbmN5",
-            "UmV3YXJkEhsKCGN1cnJlbmN5GAEgASgLMgkuQ3VycmVuY3kSDgoGYW1vdW50",
-            "GAMgASgEIi0KCkFma1Jld2FyZHMSHwoLYWZrX3Jld2FyZHMYASADKAsyCi5B",
-            "ZmtSZXdhcmQiOAoJQWZrUmV3YXJkEhsKCGN1cnJlbmN5GAEgASgLMgkuQ3Vy",
-            "cmVuY3kSDgoGYW1vdW50GAIgASgEIhcKBUVycm9yEg4KBnJlYXNvbhgBIAEo",
-            "CSIcCgVCb3hlcxITCgVib3hlcxgBIAMoCzIELkJveCKHAQoDQm94EgoKAmlk",
-            "GAEgASgJEgwKBG5hbWUYAiABKAkSEwoLZGVzY3JpcHRpb24YAyABKAkSEAoI",
-            "ZmFjdGlvbnMYBCADKAkSIgoMcmFua193ZWlnaHRzGAUgAygLMgwuUmFua1dl",
-            "aWdodHMSGwoEY29zdBgGIAMoCzINLkN1cnJlbmN5Q29zdCIrCgtSYW5rV2Vp",
-            "Z2h0cxIMCgRyYW5rGAEgASgFEg4KBndlaWdodBgCIAEoBSI7CgxDdXJyZW5j",
-            "eUNvc3QSGwoIY3VycmVuY3kYASABKAsyCS5DdXJyZW5jeRIOCgZhbW91bnQY",
-            "AiABKAUiNwoLVXNlckFuZFVuaXQSEwoEdXNlchgBIAEoCzIFLlVzZXISEwoE",
-            "dW5pdBgCIAEoCzIFLlVuaXQiUwoMQmF0dGxlUmVzdWx0Eh0KDWluaXRpYWxf",
-            "c3RhdGUYASABKAsyBi5TdGF0ZRIUCgVzdGVwcxgCIAMoCzIFLlN0ZXASDgoG",
-            "cmVzdWx0GAMgASgJIiMKBVN0YXRlEhoKBXVuaXRzGAEgAygLMgsuQmF0dGxl",
-            "VW5pdCJqCgpCYXR0bGVVbml0EgoKAmlkGAEgASgJEg4KBmhlYWx0aBgCIAEo",
-            "BRIOCgZlbmVyZ3kYAyABKAUSDAoEc2xvdBgEIAEoBRIUCgxjaGFyYWN0ZXJf",
-            "aWQYBSABKAkSDAoEdGVhbRgGIAEoBSI1CgRTdGVwEhMKC3N0ZXBfbnVtYmVy",
-            "GAEgASgFEhgKB2FjdGlvbnMYAiADKAsyBy5BY3Rpb24i/gIKBkFjdGlvbhIk",
-            "Cgxza2lsbF9hY3Rpb24YASABKAsyDC5Ta2lsbEFjdGlvbkgAEi4KEW1vZGlm",
-            "aWVyX3JlY2VpdmVkGAIgASgLMhEuTW9kaWZpZXJSZWNlaXZlZEgAEiQKDHRh",
-            "Z19yZWNlaXZlZBgDIAEoCzIMLlRhZ1JlY2VpdmVkSAASLAoQbW9kaWZpZXJf",
-            "ZXhwaXJlZBgEIAEoCzIQLk1vZGlmaWVyRXhwaXJlZEgAEiIKC3RhZ19leHBp",
-            "cmVkGAUgASgLMgsuVGFnRXhwaXJlZEgAEhcKBWRlYXRoGAYgASgLMgYuRGVh",
-            "dGhIABIwChJleGVjdXRpb25fcmVjZWl2ZWQYByABKAsyEi5FeGVjdXRpb25S",
-            "ZWNlaXZlZEgAEiQKDGVuZXJneV9yZWdlbhgIIAEoCzIMLkVuZXJneVJlZ2Vu",
-            "SAASJgoNc3RhdF9vdmVycmlkZRgJIAEoCzINLlN0YXRPdmVycmlkZUgAQg0K",
-            "C2FjdGlvbl90eXBlIjMKDFN0YXRBZmZlY3RlZBITCgRzdGF0GAEgASgOMgUu",
-            "U3RhdBIOCgZhbW91bnQYAiABKAIicwoLU2tpbGxBY3Rpb24SEQoJY2FzdGVy",
-            "X2lkGAEgASgJEhIKCnRhcmdldF9pZHMYAiADKAkSEAoIc2tpbGxfaWQYAyAB",
-            "KAkSKwoRc2tpbGxfYWN0aW9uX3R5cGUYBCABKA4yEC5Ta2lsbEFjdGlvblR5",
-            "cGUiTAoRRXhlY3V0aW9uUmVjZWl2ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEiQK",
-            "DXN0YXRfYWZmZWN0ZWQYAiABKAsyDS5TdGF0QWZmZWN0ZWQiXQoQTW9kaWZp",
-            "ZXJSZWNlaXZlZBIQCghza2lsbF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiAB",
-            "KAkSJAoNc3RhdF9hZmZlY3RlZBgDIAEoCzINLlN0YXRBZmZlY3RlZCJECgtU",
-            "YWdSZWNlaXZlZBIQCghza2lsbF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiAB",
-            "KAkSEAoIdGFnX25hbWUYAyABKAkiXAoPTW9kaWZpZXJFeHBpcmVkEhAKCHNr",
-            "aWxsX2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIkCg1zdGF0X2FmZmVj",
-            "dGVkGAMgASgLMg0uU3RhdEFmZmVjdGVkIkMKClRhZ0V4cGlyZWQSEAoIc2tp",
-            "bGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJEhAKCHRhZ19uYW1lGAMg",
-            "ASgJIhgKBURlYXRoEg8KB3VuaXRfaWQYASABKAkiQgoLRW5lcmd5UmVnZW4S",
-            "EQoJdGFyZ2V0X2lkGAEgASgJEhAKCHNraWxsX2lkGAIgASgJEg4KBmFtb3Vu",
-            "dBgDIAEoAiJHCgxTdGF0T3ZlcnJpZGUSEQoJdGFyZ2V0X2lkGAEgASgJEiQK",
-            "DXN0YXRfYWZmZWN0ZWQYAiABKAsyDS5TdGF0QWZmZWN0ZWQqWwoPU2tpbGxB",
-            "Y3Rpb25UeXBlEhMKD0FOSU1BVElPTl9TVEFSVBAAEhIKDkVGRkVDVF9UUklH",
-            "R0VSEAESDgoKRUZGRUNUX0hJVBACEg8KC0VGRkVDVF9NSVNTEAMqWAoEU3Rh",
-            "dBIKCgZIRUFMVEgQABIKCgZFTkVSR1kQARIKCgZBVFRBQ0sQAhILCgdERUZF",
-            "TlNFEAMSFAoQREFNQUdFX1JFRFVDVElPThAEEgkKBVNQRUVEEAVCFKoCEVBy",
-            "b3RvYnVmLk1lc3NhZ2VzYgZwcm90bzM="));
+            "ZBgCIAEoCRIQCghsZXZlbF9pZBgDIAEoCRIbChNzdXBlcl9jYW1wYWlnbl9u",
+            "YW1lGAQgASgJIlgKDUFma1Jld2FyZFJhdGUSHAoUa2FsaW5lX3RyZWVfbGV2",
+            "ZWxfaWQYASABKAkSGwoIY3VycmVuY3kYAiABKAsyCS5DdXJyZW5jeRIMCgRy",
+            "YXRlGAMgASgCIjsKDFVzZXJDdXJyZW5jeRIbCghjdXJyZW5jeRgBIAEoCzIJ",
+            "LkN1cnJlbmN5Eg4KBmFtb3VudBgCIAEoDSIYCghDdXJyZW5jeRIMCgRuYW1l",
+            "GAEgASgJIr4BCgRVbml0EgoKAmlkGAEgASgJEg0KBWxldmVsGAIgASgNEgwK",
+            "BHRpZXIYAyABKA0SDAoEcmFuaxgEIAEoDRIQCghzZWxlY3RlZBgFIAEoCBIM",
+            "CgRzbG90GAYgASgNEhkKEWNhbXBhaWduX2xldmVsX2lkGAcgASgJEg8KB3Vz",
+            "ZXJfaWQYCCABKAkSHQoJY2hhcmFjdGVyGAkgASgLMgouQ2hhcmFjdGVyEhQK",
+            "BWl0ZW1zGAogAygLMgUuSXRlbSIdCgVVbml0cxIUCgV1bml0cxgBIAMoCzIF",
+            "LlVuaXQiTgoRVW5pdEFuZEN1cnJlbmNpZXMSEwoEdW5pdBgBIAEoCzIFLlVu",
+            "aXQSJAoNdXNlcl9jdXJyZW5jeRgCIAMoCzINLlVzZXJDdXJyZW5jeSJLCglD",
+            "aGFyYWN0ZXISDgoGYWN0aXZlGAEgASgIEgwKBG5hbWUYAiABKAkSDwoHZmFj",
+            "dGlvbhgDIAEoCRIPCgdxdWFsaXR5GAQgASgNImQKBEl0ZW0SCgoCaWQYASAB",
+            "KAkSDQoFbGV2ZWwYAiABKA0SHwoIdGVtcGxhdGUYAyABKAsyDS5JdGVtVGVt",
+            "cGxhdGUSDwoHdXNlcl9pZBgEIAEoCRIPCgd1bml0X2lkGAUgASgJIjYKDEl0",
+            "ZW1UZW1wbGF0ZRIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEgwKBHR5cGUY",
+            "AyABKAkiKQoJQ2FtcGFpZ25zEhwKCWNhbXBhaWducxgBIAMoCzIJLkNhbXBh",
+            "aWduImQKCENhbXBhaWduEgoKAmlkGAEgASgJEhsKE3N1cGVyX2NhbXBhaWdu",
+            "X25hbWUYAiABKAkSFwoPY2FtcGFpZ25fbnVtYmVyGAMgASgNEhYKBmxldmVs",
+            "cxgEIAMoCzIGLkxldmVsIpoBCgVMZXZlbBIKCgJpZBgBIAEoCRITCgtjYW1w",
+            "YWlnbl9pZBgCIAEoCRIUCgxsZXZlbF9udW1iZXIYAyABKA0SFAoFdW5pdHMY",
+            "BCADKAsyBS5Vbml0EikKEGN1cnJlbmN5X3Jld2FyZHMYBSADKAsyDy5DdXJy",
+            "ZW5jeVJld2FyZBIZChFleHBlcmllbmNlX3Jld2FyZBgGIAEoDSI9Cg5DdXJy",
+            "ZW5jeVJld2FyZBIbCghjdXJyZW5jeRgBIAEoCzIJLkN1cnJlbmN5Eg4KBmFt",
+            "b3VudBgDIAEoBCItCgpBZmtSZXdhcmRzEh8KC2Fma19yZXdhcmRzGAEgAygL",
+            "MgouQWZrUmV3YXJkIjgKCUFma1Jld2FyZBIbCghjdXJyZW5jeRgBIAEoCzIJ",
+            "LkN1cnJlbmN5Eg4KBmFtb3VudBgCIAEoBCIXCgVFcnJvchIOCgZyZWFzb24Y",
+            "ASABKAkiHAoFQm94ZXMSEwoFYm94ZXMYASADKAsyBC5Cb3gihwEKA0JveBIK",
+            "CgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJ",
+            "EhAKCGZhY3Rpb25zGAQgAygJEiIKDHJhbmtfd2VpZ2h0cxgFIAMoCzIMLlJh",
+            "bmtXZWlnaHRzEhsKBGNvc3QYBiADKAsyDS5DdXJyZW5jeUNvc3QiKwoLUmFu",
+            "a1dlaWdodHMSDAoEcmFuaxgBIAEoBRIOCgZ3ZWlnaHQYAiABKAUiOwoMQ3Vy",
+            "cmVuY3lDb3N0EhsKCGN1cnJlbmN5GAEgASgLMgkuQ3VycmVuY3kSDgoGYW1v",
+            "dW50GAIgASgFIjcKC1VzZXJBbmRVbml0EhMKBHVzZXIYASABKAsyBS5Vc2Vy",
+            "EhMKBHVuaXQYAiABKAsyBS5Vbml0IlMKDEJhdHRsZVJlc3VsdBIdCg1pbml0",
+            "aWFsX3N0YXRlGAEgASgLMgYuU3RhdGUSFAoFc3RlcHMYAiADKAsyBS5TdGVw",
+            "Eg4KBnJlc3VsdBgDIAEoCSIjCgVTdGF0ZRIaCgV1bml0cxgBIAMoCzILLkJh",
+            "dHRsZVVuaXQiagoKQmF0dGxlVW5pdBIKCgJpZBgBIAEoCRIOCgZoZWFsdGgY",
+            "AiABKAUSDgoGZW5lcmd5GAMgASgFEgwKBHNsb3QYBCABKAUSFAoMY2hhcmFj",
+            "dGVyX2lkGAUgASgJEgwKBHRlYW0YBiABKAUiNQoEU3RlcBITCgtzdGVwX251",
+            "bWJlchgBIAEoBRIYCgdhY3Rpb25zGAIgAygLMgcuQWN0aW9uIv4CCgZBY3Rp",
+            "b24SJAoMc2tpbGxfYWN0aW9uGAEgASgLMgwuU2tpbGxBY3Rpb25IABIuChFt",
+            "b2RpZmllcl9yZWNlaXZlZBgCIAEoCzIRLk1vZGlmaWVyUmVjZWl2ZWRIABIk",
+            "Cgx0YWdfcmVjZWl2ZWQYAyABKAsyDC5UYWdSZWNlaXZlZEgAEiwKEG1vZGlm",
+            "aWVyX2V4cGlyZWQYBCABKAsyEC5Nb2RpZmllckV4cGlyZWRIABIiCgt0YWdf",
+            "ZXhwaXJlZBgFIAEoCzILLlRhZ0V4cGlyZWRIABIXCgVkZWF0aBgGIAEoCzIG",
+            "LkRlYXRoSAASMAoSZXhlY3V0aW9uX3JlY2VpdmVkGAcgASgLMhIuRXhlY3V0",
+            "aW9uUmVjZWl2ZWRIABIkCgxlbmVyZ3lfcmVnZW4YCCABKAsyDC5FbmVyZ3lS",
+            "ZWdlbkgAEiYKDXN0YXRfb3ZlcnJpZGUYCSABKAsyDS5TdGF0T3ZlcnJpZGVI",
+            "AEINCgthY3Rpb25fdHlwZSIzCgxTdGF0QWZmZWN0ZWQSEwoEc3RhdBgBIAEo",
+            "DjIFLlN0YXQSDgoGYW1vdW50GAIgASgCInMKC1NraWxsQWN0aW9uEhEKCWNh",
+            "c3Rlcl9pZBgBIAEoCRISCgp0YXJnZXRfaWRzGAIgAygJEhAKCHNraWxsX2lk",
+            "GAMgASgJEisKEXNraWxsX2FjdGlvbl90eXBlGAQgASgOMhAuU2tpbGxBY3Rp",
+            "b25UeXBlIkwKEUV4ZWN1dGlvblJlY2VpdmVkEhEKCXRhcmdldF9pZBgBIAEo",
+            "CRIkCg1zdGF0X2FmZmVjdGVkGAIgASgLMg0uU3RhdEFmZmVjdGVkIl0KEE1v",
+            "ZGlmaWVyUmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lk",
+            "GAIgASgJEiQKDXN0YXRfYWZmZWN0ZWQYAyABKAsyDS5TdGF0QWZmZWN0ZWQi",
+            "RAoLVGFnUmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lk",
+            "GAIgASgJEhAKCHRhZ19uYW1lGAMgASgJIlwKD01vZGlmaWVyRXhwaXJlZBIQ",
+            "Cghza2lsbF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiABKAkSJAoNc3RhdF9h",
+            "ZmZlY3RlZBgDIAEoCzINLlN0YXRBZmZlY3RlZCJDCgpUYWdFeHBpcmVkEhAK",
+            "CHNraWxsX2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIQCgh0YWdfbmFt",
+            "ZRgDIAEoCSIYCgVEZWF0aBIPCgd1bml0X2lkGAEgASgJIkIKC0VuZXJneVJl",
+            "Z2VuEhEKCXRhcmdldF9pZBgBIAEoCRIQCghza2lsbF9pZBgCIAEoCRIOCgZh",
+            "bW91bnQYAyABKAIiRwoMU3RhdE92ZXJyaWRlEhEKCXRhcmdldF9pZBgBIAEo",
+            "CRIkCg1zdGF0X2FmZmVjdGVkGAIgASgLMg0uU3RhdEFmZmVjdGVkKlsKD1Nr",
+            "aWxsQWN0aW9uVHlwZRITCg9BTklNQVRJT05fU1RBUlQQABISCg5FRkZFQ1Rf",
+            "VFJJR0dFUhABEg4KCkVGRkVDVF9ISVQQAhIPCgtFRkZFQ1RfTUlTUxADKlgK",
+            "BFN0YXQSCgoGSEVBTFRIEAASCgoGRU5FUkdZEAESCgoGQVRUQUNLEAISCwoH",
+            "REVGRU5TRRADEhQKEERBTUFHRV9SRURVQ1RJT04QBBIJCgVTUEVFRBAFQhSq",
+            "AhFQcm90b2J1Zi5NZXNzYWdlc2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] { typeof(global::Protobuf.Messages.SkillActionType), typeof(global::Protobuf.Messages.Stat), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -9862,12 +9862,12 @@ namespace Protobuf.Messages
     private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignId
+    public string SuperCampaignName
     {
-      get { return superCampaignId_; }
+      get { return superCampaignName_; }
       set
       {
-        superCampaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -9905,7 +9905,7 @@ namespace Protobuf.Messages
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (CampaignId.Length != 0) hash ^= CampaignId.GetHashCode();
       if (LevelId.Length != 0) hash ^= LevelId.GetHashCode();
-      if (SuperCampaignId.Length != 0) hash ^= SuperCampaignId.GetHashCode();
+      if (SuperCampaignName.Length != 0) hash ^= SuperCampaignName.GetHashCode();
       if (_unknownFields != null)
       {
         hash ^= _unknownFields.GetHashCode();
@@ -9969,7 +9969,7 @@ namespace Protobuf.Messages
         output.WriteRawTag(26);
         output.WriteString(LevelId);
       }
-      if (SuperCampaignId.Length != 0)
+      if (SuperCampaignName.Length != 0)
       {
         output.WriteRawTag(34);
         output.WriteString(SuperCampaignName);
@@ -9998,9 +9998,9 @@ namespace Protobuf.Messages
       {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(LevelId);
       }
-      if (SuperCampaignId.Length != 0)
+      if (SuperCampaignName.Length != 0)
       {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignId);
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
       if (_unknownFields != null)
       {
@@ -10029,9 +10029,9 @@ namespace Protobuf.Messages
       {
         LevelId = other.LevelId;
       }
-      if (other.SuperCampaignId.Length != 0)
+      if (other.SuperCampaignName.Length != 0)
       {
-        SuperCampaignId = other.SuperCampaignId;
+        SuperCampaignName = other.SuperCampaignName;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -10100,7 +10100,7 @@ namespace Protobuf.Messages
             }
           case 34:
             {
-              SuperCampaignId = input.ReadString();
+              SuperCampaignName = input.ReadString();
               break;
             }
         }
@@ -13313,12 +13313,12 @@ namespace Protobuf.Messages
     private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignId
+    public string SuperCampaignName
     {
-      get { return superCampaignId_; }
+      get { return superCampaignName_; }
       set
       {
-        superCampaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -13433,7 +13433,7 @@ namespace Protobuf.Messages
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (SuperCampaignId.Length != 0)
+      if (SuperCampaignName.Length != 0)
       {
         output.WriteRawTag(18);
         output.WriteString(SuperCampaignName);
@@ -13460,9 +13460,9 @@ namespace Protobuf.Messages
       {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (SuperCampaignId.Length != 0)
+      if (SuperCampaignName.Length != 0)
       {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignId);
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
       if (CampaignNumber != 0)
       {
@@ -13488,9 +13488,9 @@ namespace Protobuf.Messages
       {
         Id = other.Id;
       }
-      if (other.SuperCampaignId.Length != 0)
+      if (other.SuperCampaignName.Length != 0)
       {
-        SuperCampaignId = other.SuperCampaignId;
+        SuperCampaignName = other.SuperCampaignName;
       }
       if (other.CampaignNumber != 0)
       {
@@ -13554,7 +13554,7 @@ namespace Protobuf.Messages
             }
           case 18:
             {
-              SuperCampaignId = input.ReadString();
+              SuperCampaignName = input.ReadString();
               break;
             }
           case 24:

--- a/client/Assets/Scripts/Protobuf/Gateway.pb.cs
+++ b/client/Assets/Scripts/Protobuf/Gateway.pb.cs
@@ -109,55 +109,55 @@ namespace Protobuf.Messages {
             "cGxhdGUSDwoHdXNlcl9pZBgEIAEoCRIPCgd1bml0X2lkGAUgASgJIjYKDEl0",
             "ZW1UZW1wbGF0ZRIKCgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEgwKBHR5cGUY",
             "AyABKAkiKQoJQ2FtcGFpZ25zEhwKCWNhbXBhaWducxgBIAMoCzIJLkNhbXBh",
-            "aWduImIKCENhbXBhaWduEgoKAmlkGAEgASgJEhkKEXN1cGVyX2NhbXBhaWdu",
-            "X2lkGAIgASgJEhcKD2NhbXBhaWduX251bWJlchgDIAEoDRIWCgZsZXZlbHMY",
-            "BCADKAsyBi5MZXZlbCKaAQoFTGV2ZWwSCgoCaWQYASABKAkSEwoLY2FtcGFp",
-            "Z25faWQYAiABKAkSFAoMbGV2ZWxfbnVtYmVyGAMgASgNEhQKBXVuaXRzGAQg",
-            "AygLMgUuVW5pdBIpChBjdXJyZW5jeV9yZXdhcmRzGAUgAygLMg8uQ3VycmVu",
-            "Y3lSZXdhcmQSGQoRZXhwZXJpZW5jZV9yZXdhcmQYBiABKA0iPQoOQ3VycmVu",
-            "Y3lSZXdhcmQSGwoIY3VycmVuY3kYASABKAsyCS5DdXJyZW5jeRIOCgZhbW91",
-            "bnQYAyABKAQiLQoKQWZrUmV3YXJkcxIfCgthZmtfcmV3YXJkcxgBIAMoCzIK",
-            "LkFma1Jld2FyZCI4CglBZmtSZXdhcmQSGwoIY3VycmVuY3kYASABKAsyCS5D",
-            "dXJyZW5jeRIOCgZhbW91bnQYAiABKAQiFwoFRXJyb3ISDgoGcmVhc29uGAEg",
-            "ASgJIhwKBUJveGVzEhMKBWJveGVzGAEgAygLMgQuQm94IocBCgNCb3gSCgoC",
-            "aWQYASABKAkSDAoEbmFtZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRIQ",
-            "CghmYWN0aW9ucxgEIAMoCRIiCgxyYW5rX3dlaWdodHMYBSADKAsyDC5SYW5r",
-            "V2VpZ2h0cxIbCgRjb3N0GAYgAygLMg0uQ3VycmVuY3lDb3N0IisKC1JhbmtX",
-            "ZWlnaHRzEgwKBHJhbmsYASABKAUSDgoGd2VpZ2h0GAIgASgFIjsKDEN1cnJl",
-            "bmN5Q29zdBIbCghjdXJyZW5jeRgBIAEoCzIJLkN1cnJlbmN5Eg4KBmFtb3Vu",
-            "dBgCIAEoBSI3CgtVc2VyQW5kVW5pdBITCgR1c2VyGAEgASgLMgUuVXNlchIT",
-            "CgR1bml0GAIgASgLMgUuVW5pdCJTCgxCYXR0bGVSZXN1bHQSHQoNaW5pdGlh",
-            "bF9zdGF0ZRgBIAEoCzIGLlN0YXRlEhQKBXN0ZXBzGAIgAygLMgUuU3RlcBIO",
-            "CgZyZXN1bHQYAyABKAkiIwoFU3RhdGUSGgoFdW5pdHMYASADKAsyCy5CYXR0",
-            "bGVVbml0IloKCkJhdHRsZVVuaXQSCgoCaWQYASABKAkSDgoGaGVhbHRoGAIg",
-            "ASgFEgwKBHNsb3QYAyABKAUSFAoMY2hhcmFjdGVyX2lkGAQgASgJEgwKBHRl",
-            "YW0YBSABKAUiNQoEU3RlcBITCgtzdGVwX251bWJlchgBIAEoBRIYCgdhY3Rp",
-            "b25zGAIgAygLMgcuQWN0aW9uIrACCgZBY3Rpb24SJAoMc2tpbGxfYWN0aW9u",
-            "GAEgASgLMgwuU2tpbGxBY3Rpb25IABIuChFtb2RpZmllcl9yZWNlaXZlZBgC",
-            "IAEoCzIRLk1vZGlmaWVyUmVjZWl2ZWRIABIkCgx0YWdfcmVjZWl2ZWQYAyAB",
-            "KAsyDC5UYWdSZWNlaXZlZEgAEiwKEG1vZGlmaWVyX2V4cGlyZWQYBCABKAsy",
-            "EC5Nb2RpZmllckV4cGlyZWRIABIiCgt0YWdfZXhwaXJlZBgFIAEoCzILLlRh",
-            "Z0V4cGlyZWRIABIXCgVkZWF0aBgGIAEoCzIGLkRlYXRoSAASMAoSZXhlY3V0",
-            "aW9uX3JlY2VpdmVkGAcgASgLMhIuRXhlY3V0aW9uUmVjZWl2ZWRIAEINCgth",
-            "Y3Rpb25fdHlwZSIzCgxTdGF0QWZmZWN0ZWQSEwoEc3RhdBgBIAEoDjIFLlN0",
-            "YXQSDgoGYW1vdW50GAIgASgCInMKC1NraWxsQWN0aW9uEhEKCWNhc3Rlcl9p",
-            "ZBgBIAEoCRISCgp0YXJnZXRfaWRzGAIgAygJEhAKCHNraWxsX2lkGAMgASgJ",
-            "EisKEXNraWxsX2FjdGlvbl90eXBlGAQgASgOMhAuU2tpbGxBY3Rpb25UeXBl",
-            "IkwKEUV4ZWN1dGlvblJlY2VpdmVkEhEKCXRhcmdldF9pZBgBIAEoCRIkCg1z",
-            "dGF0X2FmZmVjdGVkGAIgASgLMg0uU3RhdEFmZmVjdGVkIl0KEE1vZGlmaWVy",
-            "UmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJ",
-            "EiQKDXN0YXRfYWZmZWN0ZWQYAyABKAsyDS5TdGF0QWZmZWN0ZWQiRAoLVGFn",
-            "UmVjZWl2ZWQSEAoIc2tpbGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJ",
-            "EhAKCHRhZ19uYW1lGAMgASgJIlwKD01vZGlmaWVyRXhwaXJlZBIQCghza2ls",
-            "bF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiABKAkSJAoNc3RhdF9hZmZlY3Rl",
-            "ZBgDIAEoCzINLlN0YXRBZmZlY3RlZCJDCgpUYWdFeHBpcmVkEhAKCHNraWxs",
-            "X2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIQCgh0YWdfbmFtZRgDIAEo",
-            "CSIYCgVEZWF0aBIPCgd1bml0X2lkGAEgASgJKlsKD1NraWxsQWN0aW9uVHlw",
-            "ZRITCg9BTklNQVRJT05fU1RBUlQQABISCg5FRkZFQ1RfVFJJR0dFUhABEg4K",
-            "CkVGRkVDVF9ISVQQAhIPCgtFRkZFQ1RfTUlTUxADKlgKBFN0YXQSCgoGSEVB",
-            "TFRIEAASCgoGRU5FUkdZEAESCgoGQVRUQUNLEAISCwoHREVGRU5TRRADEhQK",
-            "EERBTUFHRV9SRURVQ1RJT04QBBIJCgVTUEVFRBAFQhSqAhFQcm90b2J1Zi5N",
-            "ZXNzYWdlc2IGcHJvdG8z"));
+            "aWduImQKCENhbXBhaWduEgoKAmlkGAEgASgJEhsKE3N1cGVyX2NhbXBhaWdu",
+            "X25hbWUYAiABKAkSFwoPY2FtcGFpZ25fbnVtYmVyGAMgASgNEhYKBmxldmVs",
+            "cxgEIAMoCzIGLkxldmVsIpoBCgVMZXZlbBIKCgJpZBgBIAEoCRITCgtjYW1w",
+            "YWlnbl9pZBgCIAEoCRIUCgxsZXZlbF9udW1iZXIYAyABKA0SFAoFdW5pdHMY",
+            "BCADKAsyBS5Vbml0EikKEGN1cnJlbmN5X3Jld2FyZHMYBSADKAsyDy5DdXJy",
+            "ZW5jeVJld2FyZBIZChFleHBlcmllbmNlX3Jld2FyZBgGIAEoDSI9Cg5DdXJy",
+            "ZW5jeVJld2FyZBIbCghjdXJyZW5jeRgBIAEoCzIJLkN1cnJlbmN5Eg4KBmFt",
+            "b3VudBgDIAEoBCItCgpBZmtSZXdhcmRzEh8KC2Fma19yZXdhcmRzGAEgAygL",
+            "MgouQWZrUmV3YXJkIjgKCUFma1Jld2FyZBIbCghjdXJyZW5jeRgBIAEoCzIJ",
+            "LkN1cnJlbmN5Eg4KBmFtb3VudBgCIAEoBCIXCgVFcnJvchIOCgZyZWFzb24Y",
+            "ASABKAkiHAoFQm94ZXMSEwoFYm94ZXMYASADKAsyBC5Cb3gihwEKA0JveBIK",
+            "CgJpZBgBIAEoCRIMCgRuYW1lGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJ",
+            "EhAKCGZhY3Rpb25zGAQgAygJEiIKDHJhbmtfd2VpZ2h0cxgFIAMoCzIMLlJh",
+            "bmtXZWlnaHRzEhsKBGNvc3QYBiADKAsyDS5DdXJyZW5jeUNvc3QiKwoLUmFu",
+            "a1dlaWdodHMSDAoEcmFuaxgBIAEoBRIOCgZ3ZWlnaHQYAiABKAUiOwoMQ3Vy",
+            "cmVuY3lDb3N0EhsKCGN1cnJlbmN5GAEgASgLMgkuQ3VycmVuY3kSDgoGYW1v",
+            "dW50GAIgASgFIjcKC1VzZXJBbmRVbml0EhMKBHVzZXIYASABKAsyBS5Vc2Vy",
+            "EhMKBHVuaXQYAiABKAsyBS5Vbml0IlMKDEJhdHRsZVJlc3VsdBIdCg1pbml0",
+            "aWFsX3N0YXRlGAEgASgLMgYuU3RhdGUSFAoFc3RlcHMYAiADKAsyBS5TdGVw",
+            "Eg4KBnJlc3VsdBgDIAEoCSIjCgVTdGF0ZRIaCgV1bml0cxgBIAMoCzILLkJh",
+            "dHRsZVVuaXQiWgoKQmF0dGxlVW5pdBIKCgJpZBgBIAEoCRIOCgZoZWFsdGgY",
+            "AiABKAUSDAoEc2xvdBgDIAEoBRIUCgxjaGFyYWN0ZXJfaWQYBCABKAkSDAoE",
+            "dGVhbRgFIAEoBSI1CgRTdGVwEhMKC3N0ZXBfbnVtYmVyGAEgASgFEhgKB2Fj",
+            "dGlvbnMYAiADKAsyBy5BY3Rpb24isAIKBkFjdGlvbhIkCgxza2lsbF9hY3Rp",
+            "b24YASABKAsyDC5Ta2lsbEFjdGlvbkgAEi4KEW1vZGlmaWVyX3JlY2VpdmVk",
+            "GAIgASgLMhEuTW9kaWZpZXJSZWNlaXZlZEgAEiQKDHRhZ19yZWNlaXZlZBgD",
+            "IAEoCzIMLlRhZ1JlY2VpdmVkSAASLAoQbW9kaWZpZXJfZXhwaXJlZBgEIAEo",
+            "CzIQLk1vZGlmaWVyRXhwaXJlZEgAEiIKC3RhZ19leHBpcmVkGAUgASgLMgsu",
+            "VGFnRXhwaXJlZEgAEhcKBWRlYXRoGAYgASgLMgYuRGVhdGhIABIwChJleGVj",
+            "dXRpb25fcmVjZWl2ZWQYByABKAsyEi5FeGVjdXRpb25SZWNlaXZlZEgAQg0K",
+            "C2FjdGlvbl90eXBlIjMKDFN0YXRBZmZlY3RlZBITCgRzdGF0GAEgASgOMgUu",
+            "U3RhdBIOCgZhbW91bnQYAiABKAIicwoLU2tpbGxBY3Rpb24SEQoJY2FzdGVy",
+            "X2lkGAEgASgJEhIKCnRhcmdldF9pZHMYAiADKAkSEAoIc2tpbGxfaWQYAyAB",
+            "KAkSKwoRc2tpbGxfYWN0aW9uX3R5cGUYBCABKA4yEC5Ta2lsbEFjdGlvblR5",
+            "cGUiTAoRRXhlY3V0aW9uUmVjZWl2ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEiQK",
+            "DXN0YXRfYWZmZWN0ZWQYAiABKAsyDS5TdGF0QWZmZWN0ZWQiXQoQTW9kaWZp",
+            "ZXJSZWNlaXZlZBIQCghza2lsbF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiAB",
+            "KAkSJAoNc3RhdF9hZmZlY3RlZBgDIAEoCzINLlN0YXRBZmZlY3RlZCJECgtU",
+            "YWdSZWNlaXZlZBIQCghza2lsbF9pZBgBIAEoCRIRCgl0YXJnZXRfaWQYAiAB",
+            "KAkSEAoIdGFnX25hbWUYAyABKAkiXAoPTW9kaWZpZXJFeHBpcmVkEhAKCHNr",
+            "aWxsX2lkGAEgASgJEhEKCXRhcmdldF9pZBgCIAEoCRIkCg1zdGF0X2FmZmVj",
+            "dGVkGAMgASgLMg0uU3RhdEFmZmVjdGVkIkMKClRhZ0V4cGlyZWQSEAoIc2tp",
+            "bGxfaWQYASABKAkSEQoJdGFyZ2V0X2lkGAIgASgJEhAKCHRhZ19uYW1lGAMg",
+            "ASgJIhgKBURlYXRoEg8KB3VuaXRfaWQYASABKAkqWwoPU2tpbGxBY3Rpb25U",
+            "eXBlEhMKD0FOSU1BVElPTl9TVEFSVBAAEhIKDkVGRkVDVF9UUklHR0VSEAES",
+            "DgoKRUZGRUNUX0hJVBACEg8KC0VGRkVDVF9NSVNTEAMqWAoEU3RhdBIKCgZI",
+            "RUFMVEgQABIKCgZFTkVSR1kQARIKCgZBVFRBQ0sQAhILCgdERUZFTlNFEAMS",
+            "FAoQREFNQUdFX1JFRFVDVElPThAEEgkKBVNQRUVEEAVCFKoCEVByb3RvYnVm",
+            "Lk1lc3NhZ2VzYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Protobuf.Messages.SkillActionType), typeof(global::Protobuf.Messages.Stat), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -200,7 +200,7 @@ namespace Protobuf.Messages {
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Item), global::Protobuf.Messages.Item.Parser, new[]{ "Id", "Level", "Template", "UserId", "UnitId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.ItemTemplate), global::Protobuf.Messages.ItemTemplate.Parser, new[]{ "Id", "Name", "Type" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Campaigns), global::Protobuf.Messages.Campaigns.Parser, new[]{ "Campaigns_" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Campaign), global::Protobuf.Messages.Campaign.Parser, new[]{ "Id", "SuperCampaignId", "CampaignNumber", "Levels" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Campaign), global::Protobuf.Messages.Campaign.Parser, new[]{ "Id", "SuperCampaignName", "CampaignNumber", "Levels" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Level), global::Protobuf.Messages.Level.Parser, new[]{ "Id", "CampaignId", "LevelNumber", "Units", "CurrencyRewards", "ExperienceReward" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.CurrencyReward), global::Protobuf.Messages.CurrencyReward.Parser, new[]{ "Currency", "Amount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.AfkRewards), global::Protobuf.Messages.AfkRewards.Parser, new[]{ "AfkRewards_" }, null, null, null, null),
@@ -11583,7 +11583,7 @@ namespace Protobuf.Messages {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Campaign(Campaign other) : this() {
       id_ = other.id_;
-      superCampaignId_ = other.superCampaignId_;
+      superCampaignName_ = other.superCampaignName_;
       campaignNumber_ = other.campaignNumber_;
       levels_ = other.levels_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -11607,15 +11607,15 @@ namespace Protobuf.Messages {
       }
     }
 
-    /// <summary>Field number for the "super_campaign_id" field.</summary>
-    public const int SuperCampaignIdFieldNumber = 2;
-    private string superCampaignId_ = "";
+    /// <summary>Field number for the "super_campaign_name" field.</summary>
+    public const int SuperCampaignNameFieldNumber = 2;
+    private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignId {
-      get { return superCampaignId_; }
+    public string SuperCampaignName {
+      get { return superCampaignName_; }
       set {
-        superCampaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -11658,7 +11658,7 @@ namespace Protobuf.Messages {
         return true;
       }
       if (Id != other.Id) return false;
-      if (SuperCampaignId != other.SuperCampaignId) return false;
+      if (SuperCampaignName != other.SuperCampaignName) return false;
       if (CampaignNumber != other.CampaignNumber) return false;
       if(!levels_.Equals(other.levels_)) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -11669,7 +11669,7 @@ namespace Protobuf.Messages {
     public override int GetHashCode() {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
-      if (SuperCampaignId.Length != 0) hash ^= SuperCampaignId.GetHashCode();
+      if (SuperCampaignName.Length != 0) hash ^= SuperCampaignName.GetHashCode();
       if (CampaignNumber != 0) hash ^= CampaignNumber.GetHashCode();
       hash ^= levels_.GetHashCode();
       if (_unknownFields != null) {
@@ -11694,9 +11694,9 @@ namespace Protobuf.Messages {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (SuperCampaignId.Length != 0) {
+      if (SuperCampaignName.Length != 0) {
         output.WriteRawTag(18);
-        output.WriteString(SuperCampaignId);
+        output.WriteString(SuperCampaignName);
       }
       if (CampaignNumber != 0) {
         output.WriteRawTag(24);
@@ -11717,9 +11717,9 @@ namespace Protobuf.Messages {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (SuperCampaignId.Length != 0) {
+      if (SuperCampaignName.Length != 0) {
         output.WriteRawTag(18);
-        output.WriteString(SuperCampaignId);
+        output.WriteString(SuperCampaignName);
       }
       if (CampaignNumber != 0) {
         output.WriteRawTag(24);
@@ -11739,8 +11739,8 @@ namespace Protobuf.Messages {
       if (Id.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (SuperCampaignId.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignId);
+      if (SuperCampaignName.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
       if (CampaignNumber != 0) {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(CampaignNumber);
@@ -11761,8 +11761,8 @@ namespace Protobuf.Messages {
       if (other.Id.Length != 0) {
         Id = other.Id;
       }
-      if (other.SuperCampaignId.Length != 0) {
-        SuperCampaignId = other.SuperCampaignId;
+      if (other.SuperCampaignName.Length != 0) {
+        SuperCampaignName = other.SuperCampaignName;
       }
       if (other.CampaignNumber != 0) {
         CampaignNumber = other.CampaignNumber;
@@ -11788,7 +11788,7 @@ namespace Protobuf.Messages {
             break;
           }
           case 18: {
-            SuperCampaignId = input.ReadString();
+            SuperCampaignName = input.ReadString();
             break;
           }
           case 24: {
@@ -11819,7 +11819,7 @@ namespace Protobuf.Messages {
             break;
           }
           case 18: {
-            SuperCampaignId = input.ReadString();
+            SuperCampaignName = input.ReadString();
             break;
           }
           case 24: {

--- a/client/Assets/Scripts/Shared/LevelManager.cs
+++ b/client/Assets/Scripts/Shared/LevelManager.cs
@@ -3,17 +3,27 @@ using UnityEngine;
 
 public class LevelManager : MonoBehaviour
 {
-    public void ChangeToScene(string sceneName) {
+    public void ChangeToScene(string sceneName)
+    {
         UnityEngine.SceneManagement.SceneManager.LoadScene(sceneName);
     }
 
     // This is a workaround to avoid killing the sound effect when changing scenes.
-    public void ChangeToSceneWithDelay(string sceneName) {
+    public void ChangeToSceneWithDelay(string sceneName)
+    {
         StartCoroutine(ChangeToSceneAfterSeconds(sceneName, 0.1f));
     }
 
-    public IEnumerator ChangeToSceneAfterSeconds(string sceneName, float seconds) {
+    public IEnumerator ChangeToSceneAfterSeconds(string sceneName, float seconds)
+    {
         yield return new WaitForSeconds(seconds);
         ChangeToScene(sceneName);
     }
+
+    public void ChangeToSuperCampaign(string superCampaignName)
+    {
+        CampaignsMapManager.selectedSuperCampaign = superCampaignName;
+        StartCoroutine(ChangeToSceneAfterSeconds("CampaignsMap", 0.1f));
+    }
+
 }

--- a/client/Assets/Scripts/User/User.cs
+++ b/client/Assets/Scripts/User/User.cs
@@ -31,5 +31,5 @@ public class User
     public Dictionary<Currency, int> afkMaxCurrencyReward = new Dictionary<Currency, int>();
     public int afkMaxExperienceReward = 0;
 
-	public List<(string superCampaignId, string campaignId, string levelId)> campaignsProgresses = new List<(string, string, string)>();
+    public List<(string superCampaignName, string campaignId, string levelId)> campaignsProgresses = new List<(string, string, string)>();
 }

--- a/client/ProjectSettings/ShaderGraphSettings.asset
+++ b/client/ProjectSettings/ShaderGraphSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de02f9e1d18f588468e474319d09a723, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  customInterpolatorErrorThreshold: 32
+  customInterpolatorWarningThreshold: 16

--- a/gateway.proto
+++ b/gateway.proto
@@ -255,7 +255,7 @@ option csharp_namespace = "Protobuf.Messages";
 
   message Campaign {
     string id = 1;
-    string super_campaign_id = 2;
+    string super_campaign_name = 2;
     uint32 campaign_number = 3;
     repeated Level levels = 4;
   }

--- a/gateway.proto
+++ b/gateway.proto
@@ -188,7 +188,7 @@ option csharp_namespace = "Protobuf.Messages";
     string user_id = 1;
     string campaign_id = 2;
     string level_id = 3;
-    string super_campaign_id = 4;
+    string super_campaign_name = 4;
   }
 
   message AfkRewardRate {


### PR DESCRIPTION
> [!Caution]
> To be merged with https://github.com/lambdaclass/mirra_backend/pull/614

> [!Caution]
> When merged, deploy latest changes to server or otherwise campaign will break.

Closes #457 

## Motivation

We're currently processing all the campaigns that we get from the backend as if they belonged to the same supercampaign. This breaks the changes implemented in https://github.com/lambdaclass/mirra_backend/pull/614, that now sends two different supercampaigns to the client.

## Summary of changes

Filter supercampaigns by name. 
Now the Overworld scene sends the name of the Main Campaign when the Campaigns button is clicked, so the CampaignsManager knows which supercampaign to display (this is just a patch to allow the backend to merge, a better implementation is being implemented in https://github.com/lambdaclass/champions_of_mirra/pull/444)

## How has this been tested?

Start the backend using [this branch](https://github.com/lambdaclass/mirra_backend/pull/614), and in the client go to campaigns, pick the first campaign and fight a level. Everything should still be working as usual.

## Checklist
- [X] I have tested the changes locally.
- [X] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
