### PR TITLE
Fix AssetModificationProcessor namespace breaking build

### DIFF
--- a/client/Assets/Scripts/DynamicFontAssetAutoClear.cs
+++ b/client/Assets/Scripts/DynamicFontAssetAutoClear.cs
@@ -3,6 +3,7 @@ using TMPro;
 using UnityEditor;
 using UnityEngine;
 
+#if UNITY_EDITOR
 internal class DynamicFontAssetAutoCleaner : AssetModificationProcessor
 {
     static string[] OnWillSaveAssets(string[] paths)
@@ -44,3 +45,4 @@ internal class DynamicFontAssetAutoCleaner : AssetModificationProcessor
         return paths;
     }
 }
+#endif


### PR DESCRIPTION
## Motivation

The PR [Fix dynamic font assets changing version control](https://github.com/lambdaclass/champions_of_mirra/pull/1814) broke the capacity to build the application since one of the namespaces used in the new script isn't part of the core Android development environment in Unity.

## Summary of changes

Added `#if UNITY_EDITOR` conditional encapsulating the new script so it only runs on the Unity editor, and not when building.

## How has this been tested?

To test this it's necessary to test all the steps from the previously referenced PR, try to make a build for your device and check that it's fully playable.

## Checklist
- [X] I have tested the changes locally.
- [X] I have tested the whole game after applying the changes, not only the affected areas.
- [X] I self-reviewed the changes on GitHub, line by line.
- [X] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [X] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

