### PR TITLE
Fix JWT issues when changing servers

### DIFF
--- a/client/Assets/Prefabs/ServersOptions.prefab
+++ b/client/Assets/Prefabs/ServersOptions.prefab
@@ -34,7 +34,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 818923841214956151}
-  - {fileID: 1099233914732415609}
   m_Father: {fileID: 4506445334052334876}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -174,7 +173,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61d7643ed2a634eec8f60a3be5d86efa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IP: {fileID: 569503291951164151}
+  IP: {fileID: 0}
   serverName: {fileID: 5690564450626468402}
 --- !u!1 &103087406830891457
 GameObject:
@@ -389,86 +388,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &569503291951164151
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1099233914732415609}
-  - component: {fileID: 5760251701072150443}
-  - component: {fileID: 4051644919357942909}
-  m_Layer: 5
-  m_Name: IP
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1099233914732415609
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 569503291951164151}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 966149564529060418}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5760251701072150443
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 569503291951164151}
-  m_CullTransparentMesh: 1
---- !u!114 &4051644919357942909
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 569503291951164151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: localhost
 --- !u!1 &1925575024702721535
 GameObject:
   m_ObjectHideFlags: 0
@@ -1253,7 +1172,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7493310171544602680}
-  - {fileID: 7288810795858441041}
   m_Father: {fileID: 4506445334052334876}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1393,7 +1311,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61d7643ed2a634eec8f60a3be5d86efa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IP: {fileID: 6832810301181515300}
+  IP: {fileID: 0}
   serverName: {fileID: 4258319663881038376}
 --- !u!1 &3903721961584970353
 GameObject:
@@ -1819,86 +1737,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &6832810301181515300
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7288810795858441041}
-  - component: {fileID: 4811197756914848515}
-  - component: {fileID: 3947199606246539717}
-  m_Layer: 5
-  m_Name: IP
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &7288810795858441041
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6832810301181515300}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.00008, y: 1.00008, z: 1.00008}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2581769404557688204}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 135}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4811197756914848515
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6832810301181515300}
-  m_CullTransparentMesh: 1
---- !u!114 &3947199606246539717
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6832810301181515300}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: arena-europe-testing.curseofmirra.com
 --- !u!1 &7318593759018477511
 GameObject:
   m_ObjectHideFlags: 0
@@ -1933,7 +1771,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3563085963352054448}
-  - {fileID: 8976263379468443545}
   m_Father: {fileID: 4506445334052334876}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2073,7 +1910,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61d7643ed2a634eec8f60a3be5d86efa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IP: {fileID: 7860339578528433443}
+  IP: {fileID: 0}
   serverName: {fileID: 6170709500917714641}
 --- !u!1 &7354997945137672901
 GameObject:
@@ -2291,86 +2128,6 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: SERVER URL
---- !u!1 &7860339578528433443
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8976263379468443545}
-  - component: {fileID: 7554431459883220112}
-  - component: {fileID: 4919495925534139307}
-  m_Layer: 5
-  m_Name: IP
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &8976263379468443545
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7860339578528433443}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.00008, y: 1.00008, z: 1.00008}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1555390920985765010}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -340, y: 135}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7554431459883220112
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7860339578528433443}
-  m_CullTransparentMesh: 1
---- !u!114 &4919495925534139307
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7860339578528433443}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: arena-brazil-testing.curseofmirra.com
 --- !u!1 &8206817802217038070
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Scenes/TitleScreen.unity
+++ b/client/Assets/Scenes/TitleScreen.unity
@@ -702,6 +702,21 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 99460208226340218, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 99460208226340218, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: SelectServerIP, CurseOfMirra
+      objectReference: {fileID: 0}
+    - target: {fileID: 99460208226340218, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: LOCALHOST
+      objectReference: {fileID: 0}
     - target: {fileID: 196815887905347332, guid: d126b369faf0c43198f047c8765666f0,
         type: 3}
       propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.size
@@ -816,6 +831,21 @@ PrefabInstance:
         type: 3}
       propertyPath: ButtonPressedFirstTime.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 946439947379194195, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 946439947379194195, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: SelectServerIP, CurseOfMirra
+      objectReference: {fileID: 0}
+    - target: {fileID: 946439947379194195, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: EUROPE
       objectReference: {fileID: 0}
     - target: {fileID: 1261905053734839374, guid: d126b369faf0c43198f047c8765666f0,
         type: 3}
@@ -1002,6 +1032,31 @@ PrefabInstance:
       propertyPath: ButtonPressedFirstTime.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 78456883}
+    - target: {fileID: 4115833512755757586, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4115833512755757586, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: CUSTOM
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347787105897863107, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347787105897863107, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: SelectServerIP, CurseOfMirra
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347787105897863107, guid: d126b369faf0c43198f047c8765666f0,
+        type: 3}
+      propertyPath: ButtonReleased.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: BRAZIL
+      objectReference: {fileID: 0}
     - target: {fileID: 4865202050172921010, guid: d126b369faf0c43198f047c8765666f0,
         type: 3}
       propertyPath: m_IsActive
@@ -1253,10 +1308,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95284b14e95334ed9a0890f8a3bee6ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  userName: {fileID: 0}
-  statusText: {fileID: 0}
-  loggedInScreen: {fileID: 0}
-  loggedOutScreen: {fileID: 0}
   titleScreenController: {fileID: 1365717057}
 --- !u!4 &1608732374
 Transform:

--- a/client/Assets/Scripts/SelectServerIP.cs
+++ b/client/Assets/Scripts/SelectServerIP.cs
@@ -47,10 +47,19 @@ public class SelectServerIP : MonoBehaviour
                 gatewayIp = "http://localhost:4001";
                 gatewayJwtPref = "GatewayJwtLocalhost";
                 break;
-            // case "CUSTOM":
-            //     serverIp = IP.GetComponent<Text>().text.Trim();
-            //     serverNameString = "CUSTOM";
-            //     break;
+            case "CUSTOM":
+                string serverAndGatewayIp = IP.GetComponent<InputField>().text.Trim();
+                if (!serverAndGatewayIp.Contains(" "))
+                {
+                    Debug.LogError("Custom server needs: ARENA_IP GATEWAY_IP (see space between both). You sent: " + serverAndGatewayIp);
+                    break;
+                }
+                string[] Ips = serverAndGatewayIp.Split(" ");
+                serverNameString = "CUSTOM";
+                serverIp = Ips[0];
+                gatewayIp = Ips[1];
+                gatewayJwtPref = "GatewayJwtCustom";
+                break;
             default:
                 Debug.LogError("Server selection not supported: " + server);
                 break;

--- a/client/Assets/Scripts/SelectServerIP.cs
+++ b/client/Assets/Scripts/SelectServerIP.cs
@@ -11,45 +11,71 @@ public class SelectServerIP : MonoBehaviour
     [SerializeField]
     TextMeshProUGUI serverName;
 
-    public static string serverIp;
-    public static string serverNameString;
     // TODO: This should be a config file
     #if UNITY_EDITOR
-        private const string _defaultServerName = "LOCALHOST";
-        private const string _defaultServerIp = "localhost";
+        public static string serverNameString = "LOCALHOST";
+        public static string serverIp = "localhost";
+        public static string gatewayIp = "http://localhost:4001";
+        public static string gatewayJwtPref = "GatewayJwtLocalhost";
     #else
-        private const string _defaultServerName = "BRAZIL";
-        private const string _defaultServerIp = "arena-brazil-testing.curseofmirra.com";
+        public static string serverNameString = "BRAZIL";
+        public static string serverIp = "arena-brazil-testing.curseofmirra.com";
+        public static string gatewayIp = "https://central-europe-testing.curseofmirra.com";
+        public static string gatewayJwtPref = "GatewayJwtBrazil";
     #endif
 
-    public void SetServerIp()
+
+    public void SetServerIp(string server)
     {
-        if (IP.GetComponent<Text>() != null)
+        switch (server)
         {
-            serverIp = IP.GetComponent<Text>().text.Trim();
+            case "BRAZIL":
+                serverNameString = "BRAZIL";
+                serverIp = "arena-brazil-testing.curseofmirra.com";
+                gatewayIp = "https://central-europe-testing.curseofmirra.com";
+                gatewayJwtPref = "GatewayJwtBrazil";
+                break;
+            case "EUROPE":
+                serverNameString = "EUROPE";
+                serverIp = "arena-europe-testing.curseofmirra.com";
+                gatewayIp = "https://central-europe-testing.curseofmirra.com";
+                gatewayJwtPref = "GatewayJwtEurope";
+                break;
+            case "LOCALHOST":
+                serverNameString = "LOCALHOST";
+                serverIp = "localhost";
+                gatewayIp = "http://localhost:4001";
+                gatewayJwtPref = "GatewayJwtLocalhost";
+                break;
+            // case "CUSTOM":
+            //     serverIp = IP.GetComponent<Text>().text.Trim();
+            //     serverNameString = "CUSTOM";
+            //     break;
+            default:
+                Debug.LogError("Server selection not supported: " + server);
+                break;
         }
-        else if (IP.GetComponent<InputField>() != null)
-        {
-            serverIp = IP.GetComponent<InputField>().text.Trim();
-        }
-        if (serverName.text.ToUpper() == "SET CUSTOM")
-        {
-            serverNameString = "CUSTOM";
-        }
-        else
-        {
-            serverNameString = serverName.text;
-        }
+
         ServerConnection.Instance.RefreshServerInfo();
     }
 
     public static string GetServerIp()
     {
-        return string.IsNullOrEmpty(serverIp) ? _defaultServerIp : serverIp;
+        return serverIp;
+    }
+
+    public static string GetGatewayIp()
+    {
+        return gatewayIp;
     }
 
     public static string GetServerName()
     {
-        return string.IsNullOrEmpty(serverNameString) ? _defaultServerName : serverNameString;
+        return serverNameString;
+    }
+
+    public static string GetGatewayJwtPref()
+    {
+        return gatewayJwtPref;
     }
 }

--- a/client/Assets/Scripts/SelectServerIP.cs
+++ b/client/Assets/Scripts/SelectServerIP.cs
@@ -51,7 +51,7 @@ public class SelectServerIP : MonoBehaviour
                 string serverAndGatewayIp = IP.GetComponent<InputField>().text.Trim();
                 if (!serverAndGatewayIp.Contains(" "))
                 {
-                    Debug.LogError("Custom server needs: ARENA_IP GATEWAY_IP (see space between both). You sent: " + serverAndGatewayIp);
+                    Debug.LogError("Custom server needs: ARENA_IP https://GATEWAY_IP (see space between both and http for GATEWAY_IP). You sent: " + serverAndGatewayIp);
                     break;
                 }
                 string[] Ips = serverAndGatewayIp.Split(" ");

--- a/client/Assets/Scripts/Utils/ServerUtils.cs
+++ b/client/Assets/Scripts/Utils/ServerUtils.cs
@@ -30,15 +30,7 @@ public static class ServerUtils
 
     public static string MakeGatewayHTTPUrl(string path)
     {
-        // TODO: We probably want a more dynamic way to change the gateway URL
-        // sadly for now this is the best we can do. If you happen to be live testing the app
-        // locally you will need to manually change this otherwise it will fail for you
-    #if UNITY_EDITOR
-        Debug.Log("REMEMBER Gateway URL is set to localhost, change if live testing is intended");
-        return "http://localhost:4001" + path;
-    #else
-        return "https://central-europe-testing.curseofmirra.com" + path;
-    #endif
+        return SelectServerIP.GetGatewayIp() + path;
     }
 
     public static string GetClientId()
@@ -54,14 +46,15 @@ public static class ServerUtils
 
     public static string GetGatewayToken()
     {
-
-        return PlayerPrefs.GetString("gatewayJwt");
+        string gatewayJwtPref = SelectServerIP.GetGatewayJwtPref();
+        return PlayerPrefs.GetString(gatewayJwtPref);
     }
 
     public static void SetGatewayToken(string value)
     {
 
-        PlayerPrefs.SetString("gatewayJwt", value);
+        string gatewayJwtPref = SelectServerIP.GetGatewayJwtPref();
+        PlayerPrefs.SetString(gatewayJwtPref, value);
     }
 
     public static IEnumerator GetSelectedCharacter(


### PR DESCRIPTION
## Motivation

Currently in a client if you get a JWT for one server and then change servers the client will try to re-use that same JWT. In the case of Brazil and Europe it would work cause currently they share gateway server, but if you go from localhost to Europe then you face problems. Essentially when you try to go across gateway servers and have a JWT in your client 

## Summary of changes

- Extend `SelectServerIP` to change the gateway server to use and the PlayerPrefs key where the JWT for that server is stored
  - Now `CUSTOM` expects 2 IPs, arena and server in a format `arena_ip gateway_ip` (notice the space, also gateway needs the http/https part)
- Extend `ServerUtils` to use the new information in `SelectServerIP`
- Small cleanup of unneeded `IP` prefabs

## How has this been tested?

To test this play across servers without clearing PlayerPrefs or app data

To test with Ngrok you will need to extend your configuration to be able to handle both tunnels. You can modify you ngrok config with `ngrok config edit` and putting
```yaml
tunnels:
  arena:
    proto: http
    addr: 4000
  gateway:
    proto: http
    addr: 4001
```

And then you can do `ngrok start --all`

## Checklist
- [x] I have tested the changes locally.
- [ ] I have tested the whole game after applying the changes, not only the affected areas.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

