### PR TITLE
Map value balance

### DIFF
--- a/client/Assets/Materials/Araban Mats/Araban Floor.mat
+++ b/client/Assets/Materials/Araban Mats/Araban Floor.mat
@@ -22,7 +22,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BaseMap:
-        m_Texture: {fileID: 2800000, guid: 189454b3bf104435b81e8bcc28dfea82, type: 3}
+        m_Texture: {fileID: 2800000, guid: c2b2d6bc933814b20bc6accb2afcc6f0, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:
@@ -46,7 +46,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 189454b3bf104435b81e8bcc28dfea82, type: 3}
+        m_Texture: {fileID: 2800000, guid: c2b2d6bc933814b20bc6accb2afcc6f0, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/client/Assets/Scenes/Battle/MainCamera Profile.asset
+++ b/client/Assets/Scenes/Battle/MainCamera Profile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 558a8e2b6826cf840aae193990ba9f2e, type: 3}
   m_Name: ShadowsMidtonesHighlights
   m_EditorClassIdentifier: 
-  active: 1
+  active: 0
   shadows:
     m_OverrideState: 1
     m_Value: {x: 0.89713997, y: 0.82880265, z: 1, w: 0.08494206}
@@ -115,7 +115,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 66f335fb1ffd8684294ad653bf1c7564, type: 3}
   m_Name: ColorAdjustments
   m_EditorClassIdentifier: 
-  active: 1
+  active: 0
   postExposure:
     m_OverrideState: 0
     m_Value: 1.1

--- a/client/Assets/Textures/Araban/Floor/Araban_Floor.png.meta
+++ b/client/Assets/Textures/Araban/Floor/Araban_Floor.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 189454b3bf104435b81e8bcc28dfea82
+guid: c2b2d6bc933814b20bc6accb2afcc6f0
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}


### PR DESCRIPTION
## Motivation

The map color values were outdated and in need of an update

## Summary of changes
<img width="1710" alt="Screenshot 2024-06-18 at 17 33 51" src="https://github.com/lambdaclass/champions_of_mirra/assets/82987608/ede77053-38ca-4c71-942d-11c325313523">
<img width="1690" alt="Screenshot 2024-06-18 at 17 34 03" src="https://github.com/lambdaclass/champions_of_mirra/assets/82987608/4d4570e3-8320-423a-88de-1827844d5b94">
<img width="1696" alt="Screenshot 2024-06-18 at 17 33 31" src="https://github.com/lambdaclass/champions_of_mirra/assets/82987608/c9a6d62b-8780-41f6-97e5-ecaaf980b74f">
<img width="1712" alt="Screenshot 2024-06-18 at 17 33 39" src="https://github.com/lambdaclass/champions_of_mirra/assets/82987608/d28c800c-f5c3-4088-9801-ebfffb9db103">

## How has this been tested?

Run the game in both desktop and a mobile device. The floor asset should look like the images uploaded

## Checklist
- [x] I have tested the changes locally.
- [x] I have tested the whole game after applying the changes, not only the affected areas.
- [x] I self-reviewed the changes on GitHub, line by line.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

